### PR TITLE
chore: release v0.1.0-rc1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -1,0 +1,44 @@
+on: [push, pull_request]
+
+name: "Code Hygiene Suite"
+
+env:
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  hygiene:
+    strategy:
+      matrix:
+        platform: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    # - name: Install dependencies (Ubuntu only)
+    #   if: matrix.platform == 'ubuntu-latest'
+    #   run: |
+    #       sudo apt-get update
+    #       sudo apt-get install -y libdbus-1-dev pkg-config
+
+    - name: rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Initialize Rust Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: cargo check
+      run: cargo check
+
+    - name: cargo fmt
+      run: cargo fmt --all -- --check
+
+    - name: cargo clippy
+      run: cargo clippy -- -D warnings

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,53 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,6 +44,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,41 @@
+name: "Testing Suite"
+on: [push, pull_request]
+
+jobs:
+  unit-test:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        platform: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Initialize Rust Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    #   - name: Setup pnpm
+    #     uses: pnpm/action-setup@v2
+    #     with:
+    #       version: 8
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+    #   - name: Install dependencies (Ubuntu only)
+    #     if: matrix.platform == 'ubuntu-20.04'
+    #     run: |
+    #       sudo apt-get update
+    #       sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Run test suite
+        working-directory: ./
+        run: cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-rc1.1](https://github.com/canardleteer/sem-tool/compare/v0.1.0-rc1.0...v0.1.0-rc1.1) - 2025-02-13
+
+### Added
+
+- bootstrapping things
+- dependabot
+- workflows
+
+### Fixed
+
+- rollback version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.0"
+version = "0.1.0-rc1.0"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.0-rc1.0"
+version = "0.1.0-rc1.1"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.0-rc1.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.0-rc1.0"
+version = "0.1.0-rc1.1"
 edition = "2021"
 exclude = [
     "example-data/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.0"
+version = "0.1.0-rc1.0"
 edition = "2021"
 exclude = [
     "example-data/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.0-rc1.0"
+version = "0.1.0"
 edition = "2021"
 exclude = [
     "example-data/*",

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ listed in the CLI documentation.
 You'll need to pin a version, until I move this past an RC version.
 
 ```shell
-cargo install sem-tool@0.1.0-rc1.0
+cargo install sem-tool
 ```
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ listed in the CLI documentation.
 
 ## Installing
 
-Until I put this on [crates.io](https://crates.io), you can install this
-via:
+You'll need to pin a version, until I move this past an RC version.
 
 ```shell
-cargo install --path .
+cargo install sem-tool@0.1.0-rc1.0
 ```
 
 ## Output


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.0-rc1.0 -> 0.1.0-rc1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-rc1.1](https://github.com/canardleteer/sem-tool/compare/v0.1.0-rc1.0...v0.1.0-rc1.1) - 2025-02-13

### Added

- bootstrapping things
- dependabot
- workflows

### Fixed

- rollback version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).