### PR TITLE
chore: release v0.1.0-rc1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-rc1.1](https://github.com/canardleteer/sem-tool/compare/v0.1.0-rc1.0...v0.1.0-rc1.1) - 2025-02-13
+
+### Added
+
+- dependabot
+- workflows
+
+### Other
+
+- early release things

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.0-rc1.0"
+version = "0.1.0-rc1.1"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.0-rc1.0"
+version = "0.1.0-rc1.1"
 edition = "2021"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.0-rc1.0 -> 0.1.0-rc1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-rc1.1](https://github.com/canardleteer/sem-tool/compare/v0.1.0-rc1.0...v0.1.0-rc1.1) - 2025-02-13

### Added

- dependabot
- workflows

### Other

- early release things
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).