### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/canardleteer/sem-tool/compare/v0.1.1...v0.1.2) - 2025-02-23
+
+### Added
+
+- add some lightweight cli tests
+- cli application exit codes
+- add building as part of testing
+
+### Other
+
+- update README
+- add obligatory badges
+
 ## [0.1.1](https://github.com/canardleteer/sem-tool/compare/v0.1.0...v0.1.1) - 2025-02-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/canardleteer/sem-tool/compare/v0.1.1...v0.1.2) - 2025-02-23

### Added

- add some lightweight cli tests
- cli application exit codes
- add building as part of testing

### Other

- update README
- add obligatory badges
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).