### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/canardleteer/sem-tool/compare/v0.1.4...v0.1.5) - 2025-02-27
+
+### Other
+
+- typo in cli test
+- rename cli tests
+
 ## [0.1.4](https://github.com/canardleteer/sem-tool/compare/v0.1.3...v0.1.4) - 2025-02-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/canardleteer/sem-tool/compare/v0.1.4...v0.1.5) - 2025-02-27

### Other

- typo in cli test
- rename cli tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).