### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/canardleteer/sem-tool/compare/v0.1.5...v0.1.6) - 2025-03-06
+
+### Added
+
+- sem-tool generate
+- simple cli snapshotting
+
+### Other
+
+- add note about older rand in Cargo.toml
+- sem-tool generate
+- clean up cli tests (again)
+- fixup README some more
+- limitations + release page
+
 ## [0.1.5-rc1.4](https://github.com/canardleteer/sem-tool/compare/v0.1.3...v0.1.5-rc1.4) - 2025-02-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/canardleteer/sem-tool/compare/v0.1.5...v0.1.6) - 2025-03-06

### Added

- sem-tool generate
- simple cli snapshotting

### Other

- add note about older rand in Cargo.toml
- sem-tool generate
- clean up cli tests (again)
- fixup README some more
- limitations + release page
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).