### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/canardleteer/sem-tool/compare/v0.1.7...v0.1.8) - 2025-03-09
+
+### Added
+
+- replace regex_generate with rand_regex
+- reduce binary size
+
+### Fixed
+
+- don't print empty optional data in explain
+- misc typos
+
+### Other
+
+- remove stray comment
+- update insta tests
+- sort ordered versions exactly once
+- reduce magic subcommands
+- typos
+- reduce cli test scaffolding + clippy
+- note on where to further reduce dependency size
+- remove magic command name from CLI tests
+- license pass
+- update dependencies
+
 ## [0.1.7](https://github.com/canardleteer/sem-tool/compare/v0.1.6...v0.1.7) - 2025-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/canardleteer/sem-tool/compare/v0.1.7...v0.1.8) - 2025-03-09

### Added

- replace regex_generate with rand_regex
- reduce binary size

### Fixed

- don't print empty optional data in explain
- misc typos

### Other

- remove stray comment
- update insta tests
- sort ordered versions exactly once
- reduce magic subcommands
- typos
- reduce cli test scaffolding + clippy
- note on where to further reduce dependency size
- remove magic command name from CLI tests
- license pass
- update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).