### PR TITLE
chore: performance on PreMetaSegment ascii check

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -140,14 +140,8 @@ impl fmt::Display for PreMetaSegment {
 impl From<&str> for PreMetaSegment {
     fn from(value: &str) -> Self {
         // WARNING(canardleteer): Note, the spec does not enforce any numeric limit here.
-        let digit_count = value
-            .chars()
-            .filter(|char| char.is_ascii_digit())
-            .collect::<Vec<char>>()
-            .len();
-
         PreMetaSegment {
-            kind: if digit_count == value.len() {
+            kind: if value.chars().all(|c| c.is_ascii_digit()) {
                 SegmentType::Numeric
             } else {
                 SegmentType::Ascii


### PR DESCRIPTION
rather than creating a vec of N characters, we can stop immediately when a non-numeric character is found