### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/canardleteer/sem-tool/compare/v0.1.8...v0.1.9) - 2025-03-11
+
+### Other
+
+- use Self where possible
+- misc typos
+- automigrate to rust2024
+- performance on PreMetaSegment ascii check
+
 ## [0.1.8](https://github.com/canardleteer/sem-tool/compare/v0.1.7...v0.1.8) - 2025-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 exclude = [
     "example-data/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 name = "sem-tool"
 version = "0.1.8"
-edition = "2021"
+edition = "2024"
 exclude = [
     "example-data/*",
 ]

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -73,12 +73,12 @@ impl Termination for ApplicationTermination {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub(crate) enum ApplicationOutput {
-    /// Asseration by this program
+    /// Assertion by this program
     ComparisonStatement(results::ComparisonStatement),
     /// Ordered Map representation of versions
     OrderedVersionMap(results::OrderedVersionMap),
     /// Breakdown of version
-    VersionExplaination(results::VersionExplanation),
+    VersionExplanation(results::VersionExplanation),
     /// Flat list of versions
     FlatVersionsList(results::FlatVersionsList),
     /// Flat list of strings
@@ -102,7 +102,7 @@ impl From<results::OrderedVersionMap> for ApplicationOutput {
 }
 impl From<results::VersionExplanation> for ApplicationOutput {
     fn from(value: results::VersionExplanation) -> Self {
-        ApplicationOutput::VersionExplaination(value)
+        ApplicationOutput::VersionExplanation(value)
     }
 }
 
@@ -157,7 +157,7 @@ impl fmt::Display for ApplicationOutput {
             ApplicationOutput::OrderedVersionMap(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::VersionExplaination(v) => {
+            ApplicationOutput::VersionExplanation(v) => {
                 write!(f, "{}", v)
             }
             ApplicationOutput::FlatVersionsList(v) => {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -52,11 +52,11 @@ pub(crate) enum ApplicationTermination {
 }
 
 impl ApplicationTermination {
-    pub(crate) fn new(output: ApplicationOutput, hard_success: bool) -> ApplicationTermination {
+    pub(crate) const fn new(output: ApplicationOutput, hard_success: bool) -> Self {
         if hard_success {
-            ApplicationTermination::AlwaysSuccessful(output)
+            Self::AlwaysSuccessful(output)
         } else {
-            ApplicationTermination::Normal(output)
+            Self::Normal(output)
         }
     }
 }
@@ -64,8 +64,8 @@ impl ApplicationTermination {
 impl Termination for ApplicationTermination {
     fn report(self) -> ExitCode {
         match self {
-            ApplicationTermination::Normal(application_output) => application_output.report(),
-            ApplicationTermination::AlwaysSuccessful(_application_output) => ExitCode::SUCCESS,
+            Self::Normal(application_output) => application_output.report(),
+            Self::AlwaysSuccessful(_application_output) => ExitCode::SUCCESS,
         }
     }
 }
@@ -91,42 +91,42 @@ pub(crate) enum ApplicationOutput {
 
 impl From<results::ComparisonStatement> for ApplicationOutput {
     fn from(value: results::ComparisonStatement) -> Self {
-        ApplicationOutput::ComparisonStatement(value)
+        Self::ComparisonStatement(value)
     }
 }
 
 impl From<results::OrderedVersionMap> for ApplicationOutput {
     fn from(value: results::OrderedVersionMap) -> Self {
-        ApplicationOutput::OrderedVersionMap(value)
+        Self::OrderedVersionMap(value)
     }
 }
 impl From<results::VersionExplanation> for ApplicationOutput {
     fn from(value: results::VersionExplanation) -> Self {
-        ApplicationOutput::VersionExplanation(value)
+        Self::VersionExplanation(value)
     }
 }
 
 impl From<results::FlatVersionsList> for ApplicationOutput {
     fn from(value: results::FlatVersionsList) -> Self {
-        ApplicationOutput::FlatVersionsList(value)
+        Self::FlatVersionsList(value)
     }
 }
 
 impl From<results::FilterTestResult> for ApplicationOutput {
     fn from(value: results::FilterTestResult) -> Self {
-        ApplicationOutput::FilterTestResult(value)
+        Self::FilterTestResult(value)
     }
 }
 
 impl From<results::ValidateResult> for ApplicationOutput {
     fn from(value: results::ValidateResult) -> Self {
-        ApplicationOutput::ValidateResult(value)
+        Self::ValidateResult(value)
     }
 }
 
 impl From<results::GenerateResult> for ApplicationOutput {
     fn from(value: results::GenerateResult) -> Self {
-        ApplicationOutput::FlatStringList(value.into())
+        Self::FlatStringList(value.into())
     }
 }
 
@@ -135,11 +135,9 @@ impl Termination for ApplicationOutput {
     //                     (at least for now).
     fn report(self) -> ExitCode {
         match self {
-            ApplicationOutput::ComparisonStatement(comparison_statement) => {
-                comparison_statement.report()
-            }
-            ApplicationOutput::FilterTestResult(filter_test_result) => filter_test_result.report(),
-            ApplicationOutput::ValidateResult(validate_result) => validate_result.report(),
+            Self::ComparisonStatement(comparison_statement) => comparison_statement.report(),
+            Self::FilterTestResult(filter_test_result) => filter_test_result.report(),
+            Self::ValidateResult(validate_result) => validate_result.report(),
             _ => ExitCode::SUCCESS,
         }
     }
@@ -151,25 +149,25 @@ impl Termination for ApplicationOutput {
 impl fmt::Display for ApplicationOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ApplicationOutput::ComparisonStatement(v) => {
+            Self::ComparisonStatement(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::OrderedVersionMap(v) => {
+            Self::OrderedVersionMap(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::VersionExplanation(v) => {
+            Self::VersionExplanation(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::FlatVersionsList(v) => {
+            Self::FlatVersionsList(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::FlatStringList(v) => {
+            Self::FlatStringList(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::FilterTestResult(v) => {
+            Self::FilterTestResult(v) => {
                 write!(f, "{}", v)
             }
-            ApplicationOutput::ValidateResult(v) => {
+            Self::ValidateResult(v) => {
                 write!(f, "{}", v)
             }
         }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -14,7 +14,7 @@
 //! limitations under the License.
 use std::string::FromUtf8Error;
 
-use rand::{distr::Distribution, Rng};
+use rand::{Rng, distr::Distribution};
 use semver::{BuildMetadata, Prerelease};
 
 /// Regex for Semantic Version 2.0.0, directly from the spec, with 2 changes:

--- a/src/results.rs
+++ b/src/results.rs
@@ -140,14 +140,8 @@ impl fmt::Display for PreMetaSegment {
 impl From<&str> for PreMetaSegment {
     fn from(value: &str) -> Self {
         // WARNING(canardleteer): Note, the spec does not enforce any numeric limit here.
-        let digit_count = value
-            .chars()
-            .filter(|char| char.is_ascii_digit())
-            .collect::<Vec<char>>()
-            .len();
-
         PreMetaSegment {
-            kind: if digit_count == value.len() {
+            kind: if value.chars().all(|c| c.is_ascii_digit()) {
                 SegmentType::Numeric
             } else {
                 SegmentType::Ascii

--- a/src/results.rs
+++ b/src/results.rs
@@ -35,7 +35,7 @@ pub(crate) struct ValidateResult {
 }
 
 impl ValidateResult {
-    pub(crate) fn validate(semantic_version: String, small: bool) -> ValidateResult {
+    pub(crate) fn validate(semantic_version: String, small: bool) -> Self {
         let pass = if small {
             Version::parse(&semantic_version).is_ok()
         } else {
@@ -45,7 +45,7 @@ impl ValidateResult {
                 .is_match(&semantic_version)
         };
 
-        ValidateResult { valid: pass }
+        Self { valid: pass }
     }
 }
 


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/canardleteer/sem-tool/compare/v0.1.8...v0.1.9) - 2025-03-11

### Other

- use Self where possible
- misc typos
- automigrate to rust2024
- performance on PreMetaSegment ascii check
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).