### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/canardleteer/sem-tool/compare/v0.1.10...v0.1.11) - 2026-05-27
+
+### Added
+
+- sem-tool select functionality to capture semver components
+
+### Fixed
+
+- reduce type erasure
+
+### Other
+
+- hygiene check on dist-workspace config
+- update cargo & ci deps
+- README reformatting for rumdl
+- add rumdl linting and config
+- clean up some stray longlines
+- *(deps)* bump actions/upload-artifact from 6 to 7
+- *(deps)* bump actions/download-artifact from 7 to 8
+
 ## [0.1.10](https://github.com/canardleteer/sem-tool/compare/v0.1.9...v0.1.10) - 2026-01-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/canardleteer/sem-tool/compare/v0.1.10...v0.1.11) - 2026-05-27

### Added

- sem-tool select functionality to capture semver components

### Fixed

- reduce type erasure

### Other

- hygiene check on dist-workspace config
- update cargo & ci deps
- README reformatting for rumdl
- add rumdl linting and config
- clean up some stray longlines
- *(deps)* bump actions/upload-artifact from 6 to 7
- *(deps)* bump actions/download-artifact from 7 to 8
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).