### PR TITLE
chore: release v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/canardleteer/sem-tool/compare/v0.1.11...v0.1.12) - 2026-06-21
+
+### Other
+
+- enable dependabot for cargo dependencies
+- *(deps)* bump regex and insta dev dependencies, drop clap_derive pin
+- *(deps)* bump proptest-semver to 0.1.3
+- *(deps)* bump rvben/rumdl from 0.2.4 to 0.2.16
+- remove second version pin, let dependabot do the work
+- *(deps)* bump rvben/rumdl from 0.2.2 to 0.2.4
+
 ## [0.1.11](https://github.com/canardleteer/sem-tool/compare/v0.1.10...v0.1.11) - 2026-05-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.12](https://github.com/canardleteer/sem-tool/compare/v0.1.11...v0.1.12) - 2026-06-21

### Other

- enable dependabot for cargo dependencies
- *(deps)* bump regex and insta dev dependencies, drop clap_derive pin
- *(deps)* bump proptest-semver to 0.1.3
- *(deps)* bump rvben/rumdl from 0.2.4 to 0.2.16
- remove second version pin, let dependabot do the work
- *(deps)* bump rvben/rumdl from 0.2.2 to 0.2.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).