### PR TITLE
chore(deps): proptest-semver 0.1.3 and dependency hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     # Check for updates every Monday
     schedule:
       interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "insta-cmd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+checksum = "bffdf4af1db390cf0401535d7c1303cd079a074d28d8473b026fdb6559c41403"
 dependencies = [
  "insta",
  "serde",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -617,7 +617,6 @@ version = "0.1.11"
 dependencies = [
  "assert_cmd",
  "clap",
- "clap_derive",
  "indexmap",
  "insta",
  "insta-cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-semver"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b9f8077d9da87c50f3c53b3ad5b057f41dc75f217dad86405d9b28374af022"
+checksum = "5036a0500e9c9a5800946665525a4e386dca5121bc2234113d1cd06d1ab474ef"
 dependencies = [
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ assert_cmd = "2.2.2"
 insta = { version = "1.47.2", features = ["json", "yaml"] }
 insta-cmd = "0.6.0"
 proptest = "1.11.0"
-proptest-semver = "0.1.2"
+proptest-semver = "0.1.3"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ eula = false
 [dependencies]
 rand = { version = "0.9.4", features = [ "std_rng" ] }
 clap = { version = "4.6", features = ["derive"] }
-clap_derive = "4.6.1"
 indexmap = { version = "2.14.0", features= ["serde"] }
 semver = { version = "1.0.28", features= ["serde"] }
 thiserror = "2.0.18"
@@ -49,24 +48,29 @@ rand_regex = "0.18.1"
 #                     much other than parsing a single string per application
 #                     run, I think it's reasonable to shrink down the dependency
 #                     tree at a performance cost.
-regex = { version = "1.12.3", default-features = false, features = ["std"] }
+regex = { version = "1.12.4", default-features = false, features = ["std"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 
-# NOTE(canardleteer): serde_YAML vs serde_YML:
+# NOTE(canardleteer): YAML serialization trade-offs:
 #
-#                     serde_yml is a reasonable drop in replacement, and can be
-#                     used instead. serde_yaml is probably fine for now.
-#                     serde_yml, currently "over quotes" strings, making it
-#                     harder to use with common tools like `yq`, and I haven't
-#                     taken the time to figure out how to make it stop.
+#   - `serde_yaml` (current): stable Serde integration; only used for
+#     `serde_yaml::to_string` in main. Upstream crate is deprecated/archived
+#     and has YAML 1.1 quirks.
+#
+#   - `serde_yml`: active fork with a drop-in API, but over-quotes strings in
+#     output, breaking interoperability with tools like `yq`.
+#
+#   - `saphyr-rs/saphyr` (target direction): YAML 1.2 compliant, passes the
+#     YAML test suite, correctness-first. Official `saphyr-serde` is planned;
+#     migrate when Serde integration lands from saphyr-rs rather than serde_yml.
 serde_yaml = "0.9.34"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
-insta = { version = "1.47.2", features = ["json", "yaml"] }
-insta-cmd = "0.6.0"
+insta = { version = "1.48.0", features = ["json", "yaml"] }
+insta-cmd = "0.7.0"
 proptest = "1.11.0"
 proptest-semver = "0.1.3"
 


### PR DESCRIPTION
## Summary
- Bump `proptest-semver` to 0.1.3 (published today) and confirm property tests pass
- Confirm `cargo audit` is clean
- Apply low-risk dependency updates (`regex`, `insta`, `insta-cmd`); drop redundant `clap_derive` pin; defer `rand` 0.10
- Document YAML dependency trade-offs and saphyr migration intent in Cargo.toml
- Enable Dependabot for Cargo

## Test plan
- [ ] `cargo test` (all platforms via CI)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo audit`