### PR TITLE
chore(deps): bump rand, rand_regex, and rumdl action

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -75,9 +75,8 @@ jobs:
       with:
         submodules: true
 
-    # https://rumdl.dev/usage/ci-cd/ — pin both the action tag, which 
-    # aligns with the rumdl version
+    # https://rumdl.dev/usage/ci-cd/ — @v0 tracks the latest v0.x release.
 
-    - uses: rvben/rumdl@v0.2.16
+    - uses: rvben/rumdl@v0
       with:
         config: .rumdl.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +192,15 @@ dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -250,6 +270,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -445,7 +466,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -510,7 +531,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -520,7 +552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -533,12 +565,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_regex"
-version = "0.18.1"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04db2e382d13679a1e42400e90e306cdbb79dc5cd41bb035ba4eae72e78cdf37"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e745eeef604742ec751000e44d91cdc0552aacacb2c74bee88cc7685918cfa"
 dependencies = [
- "rand",
+ "rand 0.10.1",
  "regex-syntax",
 ]
 
@@ -548,7 +586,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -622,7 +660,7 @@ dependencies = [
  "insta-cmd",
  "proptest",
  "proptest-semver",
- "rand",
+ "rand 0.10.1",
  "rand_regex",
  "regex",
  "semver",
@@ -728,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ license = false
 eula = false
 
 [dependencies]
-rand = { version = "0.9.4", features = [ "std_rng" ] }
+rand = { version = "0.10.1", features = [ "std_rng" ] }
 clap = { version = "4.6", features = ["derive"] }
 indexmap = { version = "2.14.0", features= ["serde"] }
 semver = { version = "1.0.28", features= ["serde"] }
 thiserror = "2.0.18"
-rand_regex = "0.18.1"
+rand_regex = "0.19.0"
 
 # NOTE(canardleteer): The inclusion of default `regex` added 3MB to the release
 #                     binary, and that left somewhat of a sour taste in my

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -14,7 +14,8 @@
 //! limitations under the License.
 use std::string::FromUtf8Error;
 
-use rand::{Rng, distr::Distribution};
+use rand::RngExt;
+use rand::distr::Distribution;
 use semver::{BuildMetadata, Prerelease};
 
 /// Regex for Semantic Version 2.0.0, directly from the spec, with 2 changes:
@@ -43,7 +44,7 @@ pub(crate) fn generate_any_valid_semver(count: usize) -> Vec<String> {
             .unwrap();
 
     (&mut rng)
-        .sample_iter(&semver)
+        .sample_iter(semver)
         .take(count)
         .collect::<Vec<String>>()
 }
@@ -53,11 +54,8 @@ pub(crate) fn generate_any_valid_semver(count: usize) -> Vec<String> {
 ///
 /// This could probably be done better.
 pub(crate) fn generate_u64_safe_semver(count: usize) -> Vec<String> {
-    type RandomStringRegexIter = rand::distr::Iter<
-        rand_regex::Regex,
-        rand::prelude::ThreadRng,
-        Result<std::string::String, FromUtf8Error>,
-    >;
+    type RandomStringRegexIter =
+        rand::distr::Iter<rand_regex::Regex, rand::rngs::ThreadRng, Result<String, FromUtf8Error>>;
 
     let mut rng = rand::rng();
 


### PR DESCRIPTION
## Summary

- Bump `rand` to 0.10.1 and `rand_regex` to 0.19.0 together (required — rand_regex 0.19 depends on rand 0.10).
- Update `src/regex.rs` for rand 0.10 API (`RngExt`, `Distribution::sample_iter`).
- Pin rumdl CI action to `rvben/rumdl@v0` instead of a fixed patch tag.

Supersedes dependabot PRs #78, #80, and #81.

## Test plan

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, including proptest property tests)

After merge to `main` with green CI, close dependabot PRs #78, #80, and #81.