### PR TITLE
feat(cli): parity commands and proptest gap coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,56 @@ $ sem-tool set 0.0.1 --set-patch 20
 mutated_version: 0.0.20
 ```
 
+### `bump-reset`
+
+Reset-on-bump: increment one numeric segment and zero less significant ones.
+Additive arithmetic without resetting lower segments stays on **`bump`**. To
+replace or clear a segment without bumping, use **`set`** (for example,
+`set 1.0.0-rc.1 --set-pre-release=""` to drop prerelease only).
+
+| Invocation | Example in → out |
+|------------|------------------|
+| `bump-reset <ver>` *(default)* | `1.2.3-rc.1+ci` → `1.3.0-rc.1+ci` |
+| `bump-reset <ver> --major` | `1.2.3-rc.1+ci` → `2.0.0-rc.1+ci` |
+| + `--clear-pre-release` / `--clear-build-metadata` / `--normal-version-only` | Strip segments after the bump |
+
+```shell
+$ sem-tool -o text bump-reset 1.2.3
+1.3.0
+
+$ sem-tool -o text bump-reset 1.2.3-rc.1+ci --normal-version-only
+1.3.0
+```
+
+### `min`, `max`, and `latest`
+
+Return a single boundary answer from a version list (stdin or arguments), using
+the same ordering path as **`sort`**. For a full grouped list use **`sort`** (and
+`sort --flatten` for scripting). For global ambiguity across any tie group use
+**`sort --fail-if-potentially-ambiguous`**.
+
+**`latest`** is an alias for **`max`**.
+
+When the boundary group has multiple build-metadata variants at the same
+precedence (SemVer §10), the command **fails by default**. Use
+**`--allow-ambiguous`** to emit all ties, or **`--lexical-sorting`** for a
+documented non-spec lexical tiebreak (`lexical_tiebreak_used` in YAML/JSON).
+
+**`--stable`** excludes versions with non-empty pre-release before aggregation
+(documented filter opinion, same as peer `latest --stable`). Also available on
+**`sort`**.
+
+```shell
+$ sem-tool -o text max 1.0.0 2.0.0 1.5.0
+2.0.0
+
+$ sem-tool -o text max --stable 1.0.0-alpha 1.0.0 2.0.0
+2.0.0
+
+$ sem-tool max 0.1.2+bm0 0.1.2+bm1
+Error: ambiguous boundary (same precedence, differing build metadata)
+```
+
 ### `select`
 
 Get a single component (major, minor, patch, pre-release, build-metadata) from a
@@ -406,6 +456,14 @@ $ cat example-data/short-good-versions.txt | sem-tool  -o text sort --flatten -r
 0.2.0
 0.0.2
 0.0.1
+
+# exclude prerelease versions before ordering (opt-in filter opinion)
+$ sem-tool sort --stable --flatten 1.0.0-alpha 1.0.0 2.0.0
+---
+versions:
+- 1.0.0
+- 2.0.0
+potentially_ambiguous: false
 ```
 
 ### `generate`

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,41 @@ pub struct Args {
     out: OutputFormat,
 }
 
+/// Shared arguments for min, max, and latest.
+#[derive(clap::Args, Debug, Clone)]
+struct BoundaryListArgs {
+    #[clap(long, short = 'f', default_value = None)]
+    /// Only consider versions that match a filter.
+    ///
+    /// See `sort --help` for VersionReq documentation.
+    filter: Option<VersionReq>,
+
+    #[clap(long, action)]
+    /// Lexical tiebreak when build-metadata variants share precedence (SemVer §10).
+    ///
+    /// WARNING: non-spec total order; sets `lexical_tiebreak_used` in output.
+    lexical_sorting: bool,
+
+    #[clap(long, short = 'r', action)]
+    /// Reverses ordering of input before grouping (see `sort --help`).
+    reverse: bool,
+
+    #[clap(long, action)]
+    /// Exclude versions with non-empty pre-release before aggregation.
+    stable: bool,
+
+    #[clap(long, action)]
+    /// When the boundary group has multiple build-metadata variants, emit all
+    /// ties instead of failing.
+    allow_ambiguous: bool,
+
+    /// Versions as arguments, or read one per line from stdin when omitted.
+    versions: Option<Vec<Version>>,
+}
+
 /// All commands available
 #[derive(Subcommand, Debug, Clone)]
-pub enum Commands {
+enum Commands {
     /// Explain a valid Semantic Version as parsed by the spec.
     ///
     /// Breaks apart the Semantic Version, into it's individual components.
@@ -303,6 +335,28 @@ pub enum Commands {
         #[clap(long, action)]
         normal_version_only: bool,
     },
+    /// Return the minimum semantic precedence version from a list.
+    ///
+    /// For a full grouped list use **`sort`** (and `sort --flatten` for
+    /// scripting). For global ambiguity across any tie group use
+    /// **`sort --fail-if-potentially-ambiguous`**.
+    Min {
+        #[command(flatten)]
+        boundary: BoundaryListArgs,
+    },
+    /// Return the maximum semantic precedence version from a list.
+    ///
+    /// For a full grouped list use **`sort`**. For latest stable among inputs
+    /// use **`max --stable`** (documented prerelease filter).
+    Max {
+        #[command(flatten)]
+        boundary: BoundaryListArgs,
+    },
+    /// Alias for **`max`**.
+    Latest {
+        #[command(flatten)]
+        boundary: BoundaryListArgs,
+    },
     /// Select a single component from a valid Semantic Version.
     ///
     /// By default uses the official semver regex (spec-compliant, supports any
@@ -360,38 +414,15 @@ fn main() -> Result<ExitOutcome, Box<dyn Error>> {
             fail_if_potentially_ambiguous,
             stable,
         } => {
-            let mut parsed_versions = Vec::new();
+            let mut parsed_versions = parse_versions(versions)?;
 
-            // Read from stdin, or pass forward the pre-parsed list from the arguments
-            match versions {
-                Some(versions) => parsed_versions = versions,
-                None => {
-                    let lines = io::stdin().lines();
-                    for (line_no, line) in lines.enumerate() {
-                        match line {
-                            Ok(line) => {
-                                let line = line.trim();
-                                parsed_versions.push(Version::parse(line)
-                                .map_err(|e| {
-                                    eprintln!("unable to parse an enumerated version: line {line_no}: {line}: {e}");
-                                    e
-                                })?);
-                                Ok(())
-                            }
-                            Err(e) => {
-                                eprintln!("unable to read from stdin: {e}");
-                                Err(ApplicationError::InvalidArgument {
-                                    expected: "to be able to read from stdin".to_string(),
-                                    found: e.to_string(),
-                                })
-                            }
-                        }?
-                    }
-                }
-            }
-
-            let mut ordered_version_list =
-                sort(&mut parsed_versions, &filter, lexical_sorting, reverse, stable);
+            let mut ordered_version_list = sort(
+                &mut parsed_versions,
+                &filter,
+                lexical_sorting,
+                reverse,
+                stable,
+            );
 
             if fail_if_potentially_ambiguous && ordered_version_list.potentially_ambiguous() {
                 return Err(Box::new(misc::ApplicationError::FailedRequirementError {
@@ -447,6 +478,9 @@ fn main() -> Result<ExitOutcome, Box<dyn Error>> {
             normal_version_only,
         )?
         .into(),
+        Commands::Min { boundary } => boundary_versions(BoundaryKind::Min, boundary)?.into(),
+        Commands::Max { boundary } => boundary_versions(BoundaryKind::Max, boundary)?.into(),
+        Commands::Latest { boundary } => boundary_versions(BoundaryKind::Max, boundary)?.into(),
         Commands::Select {
             component,
             version,
@@ -473,6 +507,37 @@ fn main() -> Result<ExitOutcome, Box<dyn Error>> {
     Ok(ExitOutcome::new(result, ignore_exit_status_from_output))
 }
 
+fn parse_versions(versions: Option<Vec<Version>>) -> Result<Vec<Version>, Box<dyn Error>> {
+    match versions {
+        Some(versions) => Ok(versions),
+        None => {
+            let mut parsed_versions = Vec::new();
+            let lines = io::stdin().lines();
+            for (line_no, line) in lines.enumerate() {
+                match line {
+                    Ok(line) => {
+                        let line = line.trim();
+                        parsed_versions.push(Version::parse(line).map_err(|e| {
+                            eprintln!(
+                                "unable to parse an enumerated version: line {line_no}: {line}: {e}"
+                            );
+                            e
+                        })?);
+                    }
+                    Err(e) => {
+                        eprintln!("unable to read from stdin: {e}");
+                        return Err(Box::new(ApplicationError::InvalidArgument {
+                            expected: "to be able to read from stdin".to_string(),
+                            found: e.to_string(),
+                        }));
+                    }
+                }
+            }
+            Ok(parsed_versions)
+        }
+    }
+}
+
 fn sort(
     versions: &mut Vec<Version>,
     filter: &Option<VersionReq>,
@@ -481,6 +546,32 @@ fn sort(
     stable: bool,
 ) -> OrderedVersionMap {
     OrderedVersionMap::new(versions, filter, lexical_sorting, reverse, stable)
+}
+
+fn boundary_versions(
+    kind: BoundaryKind,
+    args: BoundaryListArgs,
+) -> Result<BoundaryVersionResult, Box<dyn Error>> {
+    let BoundaryListArgs {
+        filter,
+        lexical_sorting,
+        reverse,
+        stable,
+        allow_ambiguous,
+        versions,
+    } = args;
+
+    let mut parsed_versions = parse_versions(versions)?;
+    let map = sort(
+        &mut parsed_versions,
+        &filter,
+        lexical_sorting,
+        reverse,
+        stable,
+    );
+
+    BoundaryVersionResult::boundary_versions(&map, kind, allow_ambiguous, lexical_sorting, stable)
+        .map_err(|e| e.into())
 }
 
 /// Returns the semantic and lexical equivalence of 2 versions.
@@ -638,15 +729,6 @@ mod tests {
         }
 
         #[test]
-        fn set_valid_pre_build(
-            v in arb_version(),
-            pre in prop::option::of(arb_pre_release_string()),
-            build in prop::option::of(arb_build_metadata_string()),
-        ) {
-            prop_assert!(super::set(&v, None, None, None, pre, build).is_ok());
-        }
-
-        #[test]
         fn bump_reset_overflow(v in arb_version(), major_reset: bool) {
             let overflow = if major_reset { v.major == u64::MAX } else { v.minor == u64::MAX };
             let result = super::bump_reset(&v, major_reset, false, false, false);
@@ -662,6 +744,15 @@ mod tests {
                     prop_assert_eq!(out.patch, 0);
                 }
             }
+        }
+
+        #[test]
+        fn set_valid_pre_build(
+            v in arb_version(),
+            pre in prop::option::of(arb_pre_release_string()),
+            build in prop::option::of(arb_build_metadata_string()),
+        ) {
+            prop_assert!(super::set(&v, None, None, None, pre, build).is_ok());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,33 @@ pub enum Commands {
         //                     build-metadata, if we supported a selector and
         //                     confirmed the segment chosen was numeric.
     },
+    /// Reset-on-bump: increment one numeric segment and zero less significant ones.
+    ///
+    /// Additive increments without resetting lower segments → **`bump`**.
+    /// Replace or clear a segment without bumping → **`set`** (e.g.
+    /// `set <ver> --set-pre-release=""` to drop prerelease only).
+    ///
+    /// Clear flags here are bump-then-clear convenience, not a substitute for
+    /// `set`.
+    BumpReset {
+        semantic_version: Version,
+
+        /// Bump major (+1) and zero minor and patch. Default is minor-reset.
+        #[clap(long, action)]
+        major: bool,
+
+        /// Strip pre-release after the bump (preserved by default).
+        #[clap(long, action)]
+        clear_pre_release: bool,
+
+        /// Strip build metadata after the bump (preserved by default).
+        #[clap(long, action)]
+        clear_build_metadata: bool,
+
+        /// Strip both pre-release and build metadata after the bump.
+        #[clap(long, action)]
+        normal_version_only: bool,
+    },
     /// Select a single component from a valid Semantic Version.
     ///
     /// By default uses the official semver regex (spec-compliant, supports any
@@ -395,6 +422,20 @@ fn main() -> Result<ExitOutcome, Box<dyn Error>> {
             bump_minor,
             bump_patch,
         } => bump(&semantic_version, bump_major, bump_minor, bump_patch)?.into(),
+        Commands::BumpReset {
+            semantic_version,
+            major,
+            clear_pre_release,
+            clear_build_metadata,
+            normal_version_only,
+        } => bump_reset(
+            &semantic_version,
+            major,
+            clear_pre_release,
+            clear_build_metadata,
+            normal_version_only,
+        )?
+        .into(),
         Commands::Select {
             component,
             version,
@@ -470,6 +511,22 @@ fn bump(
     patch: Option<u64>,
 ) -> Result<VersionMutationResult, Box<dyn Error>> {
     VersionMutationResult::bump(version, major, minor, patch)
+}
+
+fn bump_reset(
+    version: &Version,
+    major: bool,
+    clear_pre_release: bool,
+    clear_build_metadata: bool,
+    normal_version_only: bool,
+) -> Result<VersionMutationResult, Box<dyn Error>> {
+    VersionMutationResult::bump_reset(
+        version,
+        major,
+        clear_pre_release,
+        clear_build_metadata,
+        normal_version_only,
+    )
 }
 
 fn select(
@@ -575,6 +632,24 @@ mod tests {
             build in prop::option::of(arb_build_metadata_string()),
         ) {
             prop_assert!(super::set(&v, None, None, None, pre, build).is_ok());
+        }
+
+        #[test]
+        fn bump_reset_overflow(v in arb_version(), major_reset: bool) {
+            let overflow = if major_reset { v.major == u64::MAX } else { v.minor == u64::MAX };
+            let result = super::bump_reset(&v, major_reset, false, false, false);
+            if overflow {
+                prop_assert!(result.is_err());
+            } else {
+                prop_assert!(result.is_ok());
+                let out = result.unwrap().mutated_version;
+                if major_reset {
+                    prop_assert_eq!(out.minor, 0);
+                    prop_assert_eq!(out.patch, 0);
+                } else {
+                    prop_assert_eq!(out.patch, 0);
+                }
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,16 @@ pub enum Commands {
         /// versions (multiple matching M.M.P-PR, but non-matching metadata).
         fail_if_potentially_ambiguous: bool,
 
+        /// Exclude versions with a non-empty pre-release before ordering.
+        ///
+        /// Documented filter opinion (peer `latest --stable` pattern), not
+        /// SemVer precedence. Build metadata is retained.
+        ///
+        /// For a full grouped list including prereleases, use `sort` without
+        /// this flag.
+        #[clap(long, action)]
+        stable: bool,
+
         /// If no versions are present, then the tool will read from stdin, one
         /// version per line.
         versions: Option<Vec<Version>>,
@@ -348,6 +358,7 @@ fn main() -> Result<ExitOutcome, Box<dyn Error>> {
             reverse,
             flatten,
             fail_if_potentially_ambiguous,
+            stable,
         } => {
             let mut parsed_versions = Vec::new();
 
@@ -380,7 +391,7 @@ fn main() -> Result<ExitOutcome, Box<dyn Error>> {
             }
 
             let mut ordered_version_list =
-                sort(&mut parsed_versions, &filter, lexical_sorting, reverse);
+                sort(&mut parsed_versions, &filter, lexical_sorting, reverse, stable);
 
             if fail_if_potentially_ambiguous && ordered_version_list.potentially_ambiguous() {
                 return Err(Box::new(misc::ApplicationError::FailedRequirementError {
@@ -467,8 +478,9 @@ fn sort(
     filter: &Option<VersionReq>,
     lexical_sorting: bool,
     reverse: bool,
+    stable: bool,
 ) -> OrderedVersionMap {
-    OrderedVersionMap::new(versions, filter, lexical_sorting, reverse)
+    OrderedVersionMap::new(versions, filter, lexical_sorting, reverse, stable)
 }
 
 /// Returns the semantic and lexical equivalence of 2 versions.
@@ -590,9 +602,9 @@ mod tests {
         }
 
         #[test]
-        fn sort(versions in arb_vec_versions(256), filter in arb_optional_version_req(0.5, MAX_COMPARATORS_IN_VERSION_REQ_STRING), lexical_sorting in any::<bool>(), reverse in any::<bool>()) {
+        fn sort(versions in arb_vec_versions(256), filter in arb_optional_version_req(0.5, MAX_COMPARATORS_IN_VERSION_REQ_STRING), lexical_sorting in any::<bool>(), reverse in any::<bool>(), stable in any::<bool>()) {
             let mut versions = versions.clone();
-            super::sort(&mut versions, &filter, lexical_sorting, reverse);
+            super::sort(&mut versions, &filter, lexical_sorting, reverse, stable);
         }
 
         #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,6 +485,7 @@ fn select(
 mod tests {
     use proptest::prelude::*;
     use proptest_semver::*;
+    use semver::Version;
 
     use crate::{SemverComponent, SerializableOrdering, version_without_build_metadata};
 
@@ -556,5 +557,30 @@ mod tests {
             // Just ensure we don't panic; optional components may be None
             let _ = format!("{result}");
         }
+
+        #[test]
+        fn bump_overflow(major in 1u64..=u64::MAX, minor in any::<u64>(), patch in any::<u64>()) {
+            let v = Version::parse(&format!("{major}.{minor}.{patch}")).unwrap();
+            if major == u64::MAX {
+                prop_assert!(super::bump(&v, Some(1), None, None).is_err());
+            } else {
+                prop_assert!(super::bump(&v, Some(1), None, None).is_ok());
+            }
+        }
+
+        #[test]
+        fn set_valid_pre_build(
+            v in arb_version(),
+            pre in prop::option::of(arb_pre_release_string()),
+            build in prop::option::of(arb_build_metadata_string()),
+        ) {
+            prop_assert!(super::set(&v, None, None, None, pre, build).is_ok());
+        }
+    }
+
+    #[test]
+    fn cli_short_options_do_not_conflict() {
+        use clap::CommandFactory;
+        crate::Args::command().debug_assert();
     }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -97,6 +97,8 @@ pub(crate) enum SubcommandResult {
     JustAVersion(results::VersionMutationResult),
     /// Single component selection result
     SelectResult(results::SelectResult),
+    /// Boundary min/max/latest selection
+    BoundaryVersionResult(results::BoundaryVersionResult),
 }
 
 impl From<results::ComparisonStatement> for SubcommandResult {
@@ -152,6 +154,12 @@ impl From<results::SelectResult> for SubcommandResult {
     }
 }
 
+impl From<results::BoundaryVersionResult> for SubcommandResult {
+    fn from(value: results::BoundaryVersionResult) -> Self {
+        Self::BoundaryVersionResult(value)
+    }
+}
+
 impl Termination for SubcommandResult {
     // NOTE(canardleteer): only expected to be called along certain code paths
     //                     (at least for now).
@@ -195,6 +203,9 @@ impl fmt::Display for SubcommandResult {
                 write!(f, "{}", v)
             }
             Self::SelectResult(v) => {
+                write!(f, "{}", v)
+            }
+            Self::BoundaryVersionResult(v) => {
                 write!(f, "{}", v)
             }
         }

--- a/src/results.rs
+++ b/src/results.rs
@@ -1328,13 +1328,7 @@ mod tests {
         versions
             .iter()
             .map(prop_version_without_build)
-            .min_by(|a, b| {
-                if kind_max {
-                    b.cmp(a)
-                } else {
-                    a.cmp(b)
-                }
-            })
+            .min_by(|a, b| if kind_max { b.cmp(a) } else { a.cmp(b) })
             .expect("non-empty")
     }
 
@@ -1364,9 +1358,7 @@ mod tests {
     fn prop_boundary_ambiguous(versions: &[Version], kind_max: bool) -> bool {
         let mut groups: HashMap<Version, usize> = HashMap::new();
         for v in versions {
-            *groups
-                .entry(prop_version_without_build(v))
-                .or_insert(0) += 1;
+            *groups.entry(prop_version_without_build(v)).or_insert(0) += 1;
         }
         let key = if kind_max {
             groups.keys().max().cloned()

--- a/src/results.rs
+++ b/src/results.rs
@@ -604,6 +604,93 @@ pub(crate) struct VersionMutationResult {
     pub(crate) mutated_version: Version,
 }
 
+/// Which end of the precedence-ordered version groups to select.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BoundaryKind {
+    Min,
+    Max,
+}
+
+/// Result of selecting min/max/latest from a version list.
+#[derive(Serialize, PartialEq)]
+pub(crate) struct BoundaryVersionResult {
+    pub(crate) versions: Vec<Version>,
+    pub(crate) potentially_ambiguous: bool,
+    pub(crate) lexical_tiebreak_used: bool,
+    pub(crate) stable_filter_applied: bool,
+}
+
+impl BoundaryVersionResult {
+    pub(crate) fn boundary_versions(
+        map: &OrderedVersionMap,
+        kind: BoundaryKind,
+        allow_ambiguous: bool,
+        lexical_sorting: bool,
+        stable_filter_applied: bool,
+    ) -> Result<Self, super::misc::ApplicationError> {
+        if map.inner.is_empty() {
+            return Err(super::misc::ApplicationError::FailedRequirementError {
+                err: "no versions remaining after filters".to_string(),
+            });
+        }
+
+        let (_key, group) = match kind {
+            BoundaryKind::Max => map
+                .inner
+                .iter()
+                .max_by(|a, b| a.0.cmp(b.0))
+                .expect("non-empty map"),
+            BoundaryKind::Min => map
+                .inner
+                .iter()
+                .min_by(|a, b| a.0.cmp(b.0))
+                .expect("non-empty map"),
+        };
+
+        let potentially_ambiguous = group.len() > 1;
+
+        if potentially_ambiguous && !allow_ambiguous && !lexical_sorting {
+            return Err(super::misc::ApplicationError::FailedRequirementError {
+                err: "ambiguous boundary (same precedence, differing build metadata)".to_string(),
+            });
+        }
+
+        let versions = if potentially_ambiguous && allow_ambiguous {
+            group.clone()
+        } else if potentially_ambiguous && lexical_sorting {
+            let picked = match kind {
+                BoundaryKind::Max => group.last().expect("non-empty group"),
+                BoundaryKind::Min => group.first().expect("non-empty group"),
+            };
+            vec![picked.clone()]
+        } else {
+            vec![group[0].clone()]
+        };
+
+        Ok(Self {
+            versions,
+            potentially_ambiguous,
+            lexical_tiebreak_used: potentially_ambiguous && lexical_sorting && !allow_ambiguous,
+            stable_filter_applied,
+        })
+    }
+}
+
+impl fmt::Display for BoundaryVersionResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for v in &self.versions {
+            writeln!(f, "{v}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Termination for BoundaryVersionResult {
+    fn report(self) -> ExitCode {
+        ExitCode::SUCCESS
+    }
+}
+
 impl VersionMutationResult {
     pub(crate) fn set(
         version: &Version,
@@ -1184,6 +1271,30 @@ mod tests {
 
         let normal = VersionMutationResult::bump_reset(&v, false, false, false, true).unwrap();
         assert_eq!(normal.mutated_version.to_string(), "1.3.0");
+    }
+
+    #[test]
+    fn test_boundary_versions() {
+        let mut versions: Vec<Version> = ["1.0.0", "2.0.0+bm", "2.0.0+bm2"]
+            .iter()
+            .map(|s| Version::parse(s).unwrap())
+            .collect();
+        let map = OrderedVersionMap::new(&mut versions, &None, false, false, false);
+
+        let max =
+            BoundaryVersionResult::boundary_versions(&map, BoundaryKind::Max, false, false, false);
+        assert!(max.is_err());
+
+        let max_lex =
+            BoundaryVersionResult::boundary_versions(&map, BoundaryKind::Max, false, true, false)
+                .unwrap();
+        assert_eq!(max_lex.versions.len(), 1);
+        assert!(max_lex.lexical_tiebreak_used);
+
+        let min =
+            BoundaryVersionResult::boundary_versions(&map, BoundaryKind::Min, false, false, false)
+                .unwrap();
+        assert_eq!(min.versions[0].to_string(), "1.0.0");
     }
 
     #[test]

--- a/src/results.rs
+++ b/src/results.rs
@@ -697,6 +697,53 @@ impl VersionMutationResult {
             mutated_version: response,
         })
     }
+
+    pub(crate) fn bump_reset(
+        version: &Version,
+        major_reset: bool,
+        clear_pre_release: bool,
+        clear_build_metadata: bool,
+        normal_version_only: bool,
+    ) -> Result<VersionMutationResult, Box<dyn Error>> {
+        let mut response = version.clone();
+
+        if major_reset {
+            response.major = match response.major.checked_add(1) {
+                Some(m) => m,
+                None => {
+                    return Err(
+                        format!("major bump-reset ({} + 1) overflows u64", response.major).into(),
+                    );
+                }
+            };
+            response.minor = 0;
+            response.patch = 0;
+        } else {
+            response.minor = match response.minor.checked_add(1) {
+                Some(m) => m,
+                None => {
+                    return Err(
+                        format!("minor bump-reset ({} + 1) overflows u64", response.minor).into(),
+                    );
+                }
+            };
+            response.patch = 0;
+        }
+
+        let clear_pre = normal_version_only || clear_pre_release;
+        let clear_build = normal_version_only || clear_build_metadata;
+
+        if clear_pre {
+            response.pre = Prerelease::EMPTY;
+        }
+        if clear_build {
+            response.build = BuildMetadata::EMPTY;
+        }
+
+        Ok(VersionMutationResult {
+            mutated_version: response,
+        })
+    }
 }
 
 impl fmt::Display for VersionMutationResult {
@@ -1115,6 +1162,22 @@ mod tests {
         assert!(
             VersionMutationResult::bump(&base_version, Some(2), Some(3), Some(u64::MAX)).is_err()
         );
+    }
+
+    #[test]
+    fn test_bump_reset() {
+        let v = Version::parse("1.2.3-rc.1+ci.42").unwrap();
+        let minor = VersionMutationResult::bump_reset(&v, false, false, false, false).unwrap();
+        assert_eq!(minor.mutated_version.to_string(), "1.3.0-rc.1+ci.42");
+
+        let major = VersionMutationResult::bump_reset(&v, true, false, false, false).unwrap();
+        assert_eq!(major.mutated_version.to_string(), "2.0.0-rc.1+ci.42");
+
+        let cleared = VersionMutationResult::bump_reset(&v, false, true, true, false).unwrap();
+        assert_eq!(cleared.mutated_version.to_string(), "1.3.0");
+
+        let normal = VersionMutationResult::bump_reset(&v, false, false, false, true).unwrap();
+        assert_eq!(normal.mutated_version.to_string(), "1.3.0");
     }
 
     // ComparisonStatement

--- a/src/results.rs
+++ b/src/results.rs
@@ -456,9 +456,14 @@ impl OrderedVersionMap {
         filter: &Option<VersionReq>,
         lexical_sorting: bool,
         reverse: bool,
+        stable: bool,
     ) -> Self {
         if let Some(filter) = filter {
             versions.retain(|v| filter.matches(v));
+        }
+
+        if stable {
+            versions.retain(|v| v.pre.is_empty());
         }
 
         // Generally sort the input for keys into the IndexMap.
@@ -900,7 +905,7 @@ mod tests {
             .map(|v| Version::parse(v).unwrap())
             .collect();
 
-        let test = OrderedVersionMap::new(&mut scaffold1, &None, false, false);
+        let test = OrderedVersionMap::new(&mut scaffold1, &None, false, false, false);
         assert!(test.inner.contains_key(&Version::parse("99.0.0").unwrap()));
         assert!(test.inner.contains_key(&Version::parse("100.0.0").unwrap()));
         assert!(test.inner.contains_key(&Version::parse("0.0.1").unwrap()));
@@ -933,7 +938,7 @@ mod tests {
         .map(|v| Version::parse(v).unwrap())
         .collect();
 
-        let test = OrderedVersionMap::new(&mut scaffold2, &None, false, false);
+        let test = OrderedVersionMap::new(&mut scaffold2, &None, false, false, false);
         let test_keys: Vec<Version> = test.inner.keys().cloned().collect();
         assert!(test_keys.len() == 12);
         assert!(test_keys[0] == Version::parse("0.0.0-alpha.0").unwrap());
@@ -941,7 +946,7 @@ mod tests {
         assert!(test.potentially_ambiguous);
 
         // Reverse of above test.
-        let test = OrderedVersionMap::new(&mut scaffold2, &None, false, true);
+        let test = OrderedVersionMap::new(&mut scaffold2, &None, false, true, false);
         let test_keys: Vec<Version> = test.inner.keys().cloned().collect();
         assert!(test_keys.len() == 12);
         assert!(test_keys[test_keys.len() - 1] == Version::parse("0.0.0-alpha.0").unwrap());
@@ -952,6 +957,7 @@ mod tests {
         let test = OrderedVersionMap::new(
             &mut scaffold2,
             &Some(VersionReq::parse("*").unwrap()),
+            false,
             false,
             false,
         );
@@ -996,14 +1002,14 @@ mod tests {
         .collect();
 
         // lexical sorting
-        let mut test = OrderedVersionMap::new(&mut scaffold, &None, true, false);
+        let mut test = OrderedVersionMap::new(&mut scaffold, &None, true, false, false);
         let test = FlatVersionsList::from(&mut test);
         assert!(test.versions.len() == 21);
         assert!(test.versions[0] == Version::parse("0.0.0-alpha.0+metadata").unwrap());
         assert!(test.versions[test.versions.len() - 1] == Version::parse("99.99.0-rc1.0").unwrap());
 
         // lexical sorting, reversed
-        let mut test = OrderedVersionMap::new(&mut scaffold, &None, true, true);
+        let mut test = OrderedVersionMap::new(&mut scaffold, &None, true, true, false);
         let test = FlatVersionsList::from(&mut test);
         assert!(test.versions.len() == 21);
         assert!(
@@ -1178,6 +1184,19 @@ mod tests {
 
         let normal = VersionMutationResult::bump_reset(&v, false, false, false, true).unwrap();
         assert_eq!(normal.mutated_version.to_string(), "1.3.0");
+    }
+
+    #[test]
+    fn test_ordered_version_map_stable() {
+        let mut versions: Vec<Version> = ["1.0.0-alpha", "1.0.0", "2.0.0"]
+            .iter()
+            .map(|s| Version::parse(s).unwrap())
+            .collect();
+        let map = OrderedVersionMap::new(&mut versions, &None, false, false, true);
+        assert_eq!(map.inner.len(), 2);
+        for key in map.inner.keys() {
+            assert!(key.pre.is_empty());
+        }
     }
 
     // ComparisonStatement

--- a/src/results.rs
+++ b/src/results.rs
@@ -1310,6 +1310,150 @@ mod tests {
         }
     }
 
+    use proptest::prelude::*;
+    use proptest_semver::*;
+    use std::collections::HashMap;
+
+    fn prop_version_without_build(v: &Version) -> Version {
+        Version {
+            major: v.major,
+            minor: v.minor,
+            patch: v.patch,
+            pre: v.pre.clone(),
+            build: BuildMetadata::EMPTY,
+        }
+    }
+
+    fn prop_boundary_precedence_key(versions: &[Version], kind_max: bool) -> Version {
+        versions
+            .iter()
+            .map(prop_version_without_build)
+            .min_by(|a, b| {
+                if kind_max {
+                    b.cmp(a)
+                } else {
+                    a.cmp(b)
+                }
+            })
+            .expect("non-empty")
+    }
+
+    fn prop_boundary_group_at_key(filtered: &[Version], kind_max: bool) -> Vec<Version> {
+        let key = prop_boundary_precedence_key(filtered, kind_max);
+        filtered
+            .iter()
+            .filter(|v| prop_version_without_build(v) == key)
+            .cloned()
+            .collect()
+    }
+
+    fn prop_expected_lexical_pick(filtered: &[Version], kind_max: bool, reverse: bool) -> Version {
+        let mut group = prop_boundary_group_at_key(filtered, kind_max);
+        if reverse {
+            group.sort_by(|a, b| b.cmp(a));
+        } else {
+            group.sort();
+        }
+        if kind_max {
+            group.last().expect("non-empty group").clone()
+        } else {
+            group.first().expect("non-empty group").clone()
+        }
+    }
+
+    fn prop_boundary_ambiguous(versions: &[Version], kind_max: bool) -> bool {
+        let mut groups: HashMap<Version, usize> = HashMap::new();
+        for v in versions {
+            *groups
+                .entry(prop_version_without_build(v))
+                .or_insert(0) += 1;
+        }
+        let key = if kind_max {
+            groups.keys().max().cloned()
+        } else {
+            groups.keys().min().cloned()
+        };
+        key.and_then(|k| groups.get(&k).copied())
+            .map(|c| c > 1)
+            .unwrap_or(false)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            fork: true,
+            cases: 256,
+            .. ProptestConfig::default()
+        })]
+        #[test]
+        fn prop_boundary_versions(
+            stable: bool,
+            reverse: bool,
+            lexical_sorting: bool,
+            allow_ambiguous: bool,
+            kind_max: bool,
+            filter in arb_optional_version_req(0.5, 2),
+            mut versions in arb_vec_versions(16),
+        ) {
+            let map = OrderedVersionMap::new(
+                &mut versions,
+                &filter,
+                lexical_sorting,
+                reverse,
+                stable,
+            );
+
+            let kind = if kind_max {
+                BoundaryKind::Max
+            } else {
+                BoundaryKind::Min
+            };
+
+            let result = BoundaryVersionResult::boundary_versions(
+                &map,
+                kind,
+                allow_ambiguous,
+                lexical_sorting,
+                stable,
+            );
+
+            if map.inner.is_empty() {
+                prop_assert!(result.is_err());
+            } else {
+                let filtered: Vec<Version> = map
+                    .inner
+                    .values()
+                    .flat_map(|group| group.iter().cloned())
+                    .collect();
+                let ambiguous = prop_boundary_ambiguous(&filtered, kind_max);
+                let expected_key = prop_boundary_precedence_key(&filtered, kind_max);
+
+                if ambiguous && !allow_ambiguous && !lexical_sorting {
+                    prop_assert!(result.is_err());
+                } else {
+                    let ok = result.expect("expected boundary success");
+                    if allow_ambiguous && ambiguous {
+                        prop_assert!(ok.versions.len() > 1);
+                        for v in &ok.versions {
+                            prop_assert_eq!(prop_version_without_build(v), expected_key.clone());
+                        }
+                    } else if lexical_sorting && ambiguous {
+                        prop_assert_eq!(ok.versions.len(), 1);
+                        prop_assert_eq!(
+                            ok.versions[0].clone(),
+                            prop_expected_lexical_pick(&filtered, kind_max, reverse)
+                        );
+                    } else {
+                        prop_assert_eq!(ok.versions.len(), 1);
+                        prop_assert_eq!(
+                            prop_version_without_build(&ok.versions[0]),
+                            expected_key
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // ComparisonStatement
     #[test]
     fn test_comparison_statement() {

--- a/tests/cli_bump_reset.rs
+++ b/tests/cli_bump_reset.rs
@@ -1,0 +1,135 @@
+//! SPDX-License-Identifier: Apache-2.0
+//! Copyright 2025 canardleteer
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//! http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+use proptest::prelude::*;
+use proptest_semver::*;
+use semver::Version;
+
+mod common;
+use common::subcommands::*;
+
+use crate::common::common_cmd;
+
+#[test]
+fn cli_bump_reset_invalid_input() {
+    let assert = common_cmd().arg(COMMAND_BUMP_RESET).arg("a.b.c").assert();
+    assert
+        .append_context(COMMAND_BUMP_RESET, "bad semver")
+        .failure();
+}
+
+#[test]
+fn cli_bump_reset_basic_cases() {
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_BUMP_RESET)
+        .arg("1.2.3")
+        .assert();
+    assert
+        .append_context(COMMAND_BUMP_RESET, "minor reset")
+        .stdout("1.3.0")
+        .success();
+
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_BUMP_RESET)
+        .arg("1.2.3")
+        .arg("--major")
+        .assert();
+    assert
+        .append_context(COMMAND_BUMP_RESET, "major reset")
+        .stdout("2.0.0")
+        .success();
+
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_BUMP_RESET)
+        .arg("1.2.3-rc.1+ci.42")
+        .arg("--normal-version-only")
+        .assert();
+    assert
+        .append_context(COMMAND_BUMP_RESET, "normal only")
+        .stdout("1.3.0")
+        .success();
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        fork: true,
+        cases: 256,
+        .. ProptestConfig::default()
+    })]
+    #[test]
+    fn prop_bump_reset(
+        v in arb_version(),
+        major_reset: bool,
+        clear_pre: bool,
+        clear_build: bool,
+        normal_only: bool,
+    ) {
+        let overflow = if major_reset {
+            v.major == u64::MAX
+        } else {
+            v.minor == u64::MAX
+        };
+
+        let mut cmd = common_cmd();
+        cmd.arg("-o").arg("text").arg(COMMAND_BUMP_RESET).arg(v.to_string());
+        if major_reset {
+            cmd.arg("--major");
+        }
+        if clear_pre {
+            cmd.arg("--clear-pre-release");
+        }
+        if clear_build {
+            cmd.arg("--clear-build-metadata");
+        }
+        if normal_only {
+            cmd.arg("--normal-version-only");
+        }
+
+        let assert = cmd.assert();
+        if overflow {
+            assert.append_context(COMMAND_BUMP_RESET, "overflow").failure();
+        } else {
+            let stdout_owned =
+                String::from_utf8_lossy(&assert.get_output().stdout).trim().to_string();
+            assert.append_context(COMMAND_BUMP_RESET, "success").success();
+            let parsed = Version::parse(&stdout_owned).expect("output is valid semver");
+            if major_reset {
+                prop_assert_eq!(parsed.major, v.major + 1);
+                prop_assert_eq!(parsed.minor, 0);
+                prop_assert_eq!(parsed.patch, 0);
+            } else {
+                prop_assert_eq!(parsed.minor, v.minor + 1);
+                prop_assert_eq!(parsed.patch, 0);
+            }
+            let clear_pre_effective = normal_only || clear_pre;
+            let clear_build_effective = normal_only || clear_build;
+            if clear_pre_effective {
+                prop_assert!(parsed.pre.is_empty());
+            } else if !v.pre.is_empty() {
+                prop_assert_eq!(parsed.pre.as_str(), v.pre.as_str());
+            }
+            if clear_build_effective {
+                prop_assert!(parsed.build.is_empty());
+            } else if !v.build.is_empty() {
+                prop_assert_eq!(parsed.build.as_str(), v.build.as_str());
+            }
+        }
+    }
+}

--- a/tests/cli_compare.rs
+++ b/tests/cli_compare.rs
@@ -14,11 +14,51 @@
 //! limitations under the License.
 use proptest::prelude::*;
 use proptest_semver::*;
+use semver::Version;
 
 mod common;
 use common::subcommands::*;
 
 use crate::common::common_cmd;
+
+fn compare_exit_code(a: &Version, b: &Version) -> i32 {
+    let sem = {
+        let a_nb = strip_build(a);
+        let b_nb = strip_build(b);
+        a_nb.cmp(&b_nb)
+    };
+    let lex = a.cmp(b);
+    ordering_pair_to_exit_code(sem, lex)
+}
+
+fn strip_build(v: &Version) -> Version {
+    Version {
+        major: v.major,
+        minor: v.minor,
+        patch: v.patch,
+        pre: v.pre.clone(),
+        build: semver::BuildMetadata::EMPTY,
+    }
+}
+
+fn ordering_pair_to_exit_code(sem: std::cmp::Ordering, lex: std::cmp::Ordering) -> i32 {
+    use std::cmp::Ordering::*;
+    let s = match sem {
+        Less => 0,
+        Equal => 1,
+        Greater => 2,
+    };
+    let l = match lex {
+        Less => 0,
+        Equal => 1,
+        Greater => 2,
+    };
+    if s == 1 && l == 1 {
+        0
+    } else {
+        100 + s * 10 + l
+    }
+}
 
 #[test]
 fn cli_compare_invalid_input() {
@@ -161,20 +201,49 @@ proptest! {
         .. ProptestConfig::default()
     })]
     #[test]
-    fn filter_test_semantic_equal(a in arb_version(), b in arb_version()) {
-        let assert = common_cmd().arg(COMMAND_COMPARE).arg("-s").arg(a.to_string()).arg(b.to_string()).assert();
-        assert.append_context(COMMAND_COMPARE, "property test: -s").success();
-
-        // We don't enable `--set-exit-status`, so as long as the input is clean, we should succeed.
+    fn prop_compare_no_exit_status(version_a in arb_version(), version_b in arb_version()) {
+        let assert = common_cmd()
+            .arg(COMMAND_COMPARE)
+            .arg(version_a.to_string())
+            .arg(version_b.to_string())
+            .assert();
+        assert.append_context(COMMAND_COMPARE, "property test no -e").success();
     }
 
     #[test]
-    fn filter_test_compare_no_opts(version_a in arb_version(), version_b in arb_version()) {
-        let assert = common_cmd().arg(COMMAND_COMPARE).arg("-s").arg(version_a.to_string()).arg(version_b.to_string()).assert();
-        assert.append_context(COMMAND_COMPARE, "property test").success();
+    fn prop_compare_set_exit_status(
+        version_a in arb_version(),
+        version_b in arb_version(),
+        semantic_exit_status in any::<bool>(),
+    ) {
+        let mut cmd = common_cmd();
+        cmd.arg(COMMAND_COMPARE)
+            .arg("-e")
+            .arg(version_a.to_string())
+            .arg(version_b.to_string());
+        if semantic_exit_status {
+            cmd.arg("-s");
+        }
 
-        // We don't enable `--set-exit-status`, so as long as the input is clean, we should succeed.
+        let expected = compare_exit_code(&version_a, &version_b);
+        let assert = cmd.assert();
+        if semantic_exit_status && strip_build(&version_a) == strip_build(&version_b) {
+            assert.append_context(COMMAND_COMPARE, "property test -es").success();
+        } else {
+            assert
+                .append_context(COMMAND_COMPARE, "property test -e")
+                .code(expected);
+        }
     }
 
-    // NOTE(canardleteer): A more robust test case here, would be for "-s" & "-se"
+    #[test]
+    fn prop_compare_semantic_exit_without_e(version_a in arb_version(), version_b in arb_version()) {
+        let assert = common_cmd()
+            .arg(COMMAND_COMPARE)
+            .arg("-s")
+            .arg(version_a.to_string())
+            .arg(version_b.to_string())
+            .assert();
+        assert.append_context(COMMAND_COMPARE, "property test -s only").success();
+    }
 }

--- a/tests/cli_explain.rs
+++ b/tests/cli_explain.rs
@@ -38,9 +38,29 @@ fn cli_explain_basic_cases() {
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig {
+        fork: true,
+        cases: 256,
+        .. ProptestConfig::default()
+    })]
     #[test]
     fn prop_explain(v in arb_version()) {
         let assert = common_cmd().arg(COMMAND_EXPLAIN).arg(v.to_string()).assert();
         assert.append_context(COMMAND_EXPLAIN, "property test").success();
+    }
+
+    #[test]
+    fn prop_explain_output_contains_core_version(v in arb_version()) {
+        let assert = common_cmd()
+            .arg("-o")
+            .arg("text")
+            .arg(COMMAND_EXPLAIN)
+            .arg(v.to_string())
+            .assert();
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+        assert.append_context(COMMAND_EXPLAIN, "property test text output").success();
+        assert!(stdout.contains(&format!("Major: {}", v.major)));
+        assert!(stdout.contains(&format!("Minor: {}", v.minor)));
+        assert!(stdout.contains(&format!("Patch: {}", v.patch)));
     }
 }

--- a/tests/cli_generate.rs
+++ b/tests/cli_generate.rs
@@ -13,6 +13,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 use proptest::prelude::*;
+use semver::Version;
 
 mod common;
 use common::subcommands::*;
@@ -50,18 +51,44 @@ proptest! {
         .. ProptestConfig::default()
     })]
     #[test]
-    fn prop_generate_small(count in 0u16..10) {
-        let assert = common_cmd().arg(COMMAND_GENERATE).arg("-s").arg(count.to_string()).assert();
-        assert.append_context(COMMAND_GENERATE, "property testing").success();
-
-        // Reading back input here, and validating it would be a better test.
+    fn prop_generate_small(count in 1u16..10) {
+        let assert = common_cmd()
+            .arg("-o")
+            .arg("text")
+            .arg(COMMAND_GENERATE)
+            .arg("-s")
+            .arg(count.to_string())
+            .assert();
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+        assert.append_context(COMMAND_GENERATE, "property testing -s").success();
+        let lines: Vec<&str> = stdout
+            .lines()
+            .filter(|l| !l.is_empty())
+            .collect();
+        prop_assert_eq!(lines.len(), count as usize);
+        for line in lines {
+            prop_assert!(Version::parse(line).is_ok());
+        }
     }
 
     #[test]
-    fn prop_generate_regex(count in 0u16..10) {
-        let assert = common_cmd().arg(COMMAND_GENERATE).arg(count.to_string()).assert();
-        assert.append_context(COMMAND_GENERATE, "property testing").success();
-
-        // Reading back input here, and validating it would be a better test.
+    fn prop_generate_regex(count in 1u16..10) {
+        let assert = common_cmd()
+            .arg("-o")
+            .arg("text")
+            .arg(COMMAND_GENERATE)
+            .arg(count.to_string())
+            .assert();
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+        assert.append_context(COMMAND_GENERATE, "property testing regex").success();
+        let lines: Vec<&str> = stdout
+            .lines()
+            .filter(|l| !l.is_empty())
+            .collect();
+        prop_assert_eq!(lines.len(), count as usize);
+        for line in lines {
+            let validate = common_cmd().arg(COMMAND_VALIDATE).arg(line).assert();
+            validate.success();
+        }
     }
 }

--- a/tests/cli_insta.rs
+++ b/tests/cli_insta.rs
@@ -238,6 +238,18 @@ fn cli_insta() {
         ],
     );
 
+    insta_targets.insert(
+        "sort.stable.1",
+        vec![
+            COMMAND_SORT,
+            "--stable",
+            "--flatten",
+            "1.0.0-alpha",
+            "1.0.0",
+            "2.0.0",
+        ],
+    );
+
     for (key, args) in insta_targets.iter() {
         assert_cmd_snapshot!(*key, cli().args(args));
     }

--- a/tests/cli_insta.rs
+++ b/tests/cli_insta.rs
@@ -237,13 +237,36 @@ fn cli_insta() {
             "--normal-version-only",
         ],
     );
-
     insta_targets.insert(
         "sort.stable.1",
         vec![
             COMMAND_SORT,
             "--stable",
             "--flatten",
+            "1.0.0-alpha",
+            "1.0.0",
+            "2.0.0",
+        ],
+    );
+    insta_targets.insert(
+        "max.simple.1",
+        vec!["-o", "text", COMMAND_MAX, "1.0.0", "2.0.0", "1.5.0"],
+    );
+    insta_targets.insert(
+        "min.simple.1",
+        vec!["-o", "text", COMMAND_MIN, "1.0.0", "2.0.0", "1.5.0"],
+    );
+    insta_targets.insert(
+        "latest.alias.1",
+        vec!["-o", "text", COMMAND_LATEST, "1.0.0", "2.0.0"],
+    );
+    insta_targets.insert(
+        "max.stable.1",
+        vec![
+            "-o",
+            "text",
+            COMMAND_MAX,
+            "--stable",
             "1.0.0-alpha",
             "1.0.0",
             "2.0.0",

--- a/tests/cli_insta.rs
+++ b/tests/cli_insta.rs
@@ -219,6 +219,25 @@ fn cli_insta() {
         vec![COMMAND_SELECT, "-s", "minor", "10.20.30"],
     );
 
+    insta_targets.insert(
+        "bump-reset.simple.1",
+        vec!["-o", "text", COMMAND_BUMP_RESET, "1.2.3"],
+    );
+    insta_targets.insert(
+        "bump-reset.major.1",
+        vec!["-o", "text", COMMAND_BUMP_RESET, "1.2.3", "--major"],
+    );
+    insta_targets.insert(
+        "bump-reset.clear.1",
+        vec![
+            "-o",
+            "text",
+            COMMAND_BUMP_RESET,
+            "1.2.3-rc.1+ci",
+            "--normal-version-only",
+        ],
+    );
+
     for (key, args) in insta_targets.iter() {
         assert_cmd_snapshot!(*key, cli().args(args));
     }

--- a/tests/cli_min_max.proptest-regressions
+++ b/tests/cli_min_max.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 158e408a135e4bffb182a5d932da5c649b235fc52e01ea516ae3da13a27bdb2d # shrinks to stable = false, lexical_sorting = false, allow_ambiguous = false, filter = Some(VersionReq { comparators: [Comparator { op: Tilde, major: 0, minor: None, patch: None, pre: Prerelease("") }] }), versions = [Version { major: 1, minor: 0, patch: 0 }]
+cc db76698b945a4639daf16ce92be0c93a55a7b692b37316a096d1653af224df19 # shrinks to stable = false, lexical_sorting = false, allow_ambiguous = false, filter = None, versions = [Version { major: 0, minor: 0, patch: 0 }]

--- a/tests/cli_min_max.rs
+++ b/tests/cli_min_max.rs
@@ -101,6 +101,43 @@ fn version_without_build(v: &Version) -> Version {
     }
 }
 
+fn boundary_precedence_key(versions: &[Version], kind_max: bool) -> Version {
+    versions
+        .iter()
+        .map(version_without_build)
+        .min_by(|a, b| {
+            if kind_max {
+                b.cmp(a)
+            } else {
+                a.cmp(b)
+            }
+        })
+        .expect("non-empty")
+}
+
+fn boundary_group_at_key(filtered: &[Version], kind_max: bool) -> Vec<Version> {
+    let key = boundary_precedence_key(filtered, kind_max);
+    filtered
+        .iter()
+        .filter(|v| version_without_build(v) == key)
+        .cloned()
+        .collect()
+}
+
+fn expected_lexical_pick(filtered: &[Version], kind_max: bool, reverse: bool) -> Version {
+    let mut group = boundary_group_at_key(filtered, kind_max);
+    if reverse {
+        group.sort_by(|a, b| b.cmp(a));
+    } else {
+        group.sort();
+    }
+    if kind_max {
+        group.last().expect("non-empty group").clone()
+    } else {
+        group.first().expect("non-empty group").clone()
+    }
+}
+
 fn boundary_ambiguous(versions: &[Version], kind_max: bool) -> bool {
     if versions.is_empty() {
         return false;
@@ -144,6 +181,7 @@ fn boundary_test_generic(
     command: &'static str,
     kind_max: bool,
     stable: bool,
+    reverse: bool,
     lexical_sorting: bool,
     allow_ambiguous: bool,
     filter: Option<VersionReq>,
@@ -154,6 +192,9 @@ fn boundary_test_generic(
         let mut args = vec!["-o".to_string(), "text".to_string(), command.to_string()];
         if stable {
             args.push("--stable".to_string());
+        }
+        if reverse {
+            args.push("--reverse".to_string());
         }
         if let Some(filter) = &filter {
             args.push("--filter".to_string());
@@ -169,10 +210,14 @@ fn boundary_test_generic(
     }
 
     let ambiguous = boundary_ambiguous(&filtered, kind_max);
+    let expected_key = boundary_precedence_key(&filtered, kind_max);
 
     let mut args = vec!["-o".to_string(), "text".to_string(), command.to_string()];
     if stable {
         args.push("--stable".to_string());
+    }
+    if reverse {
+        args.push("--reverse".to_string());
     }
     if lexical_sorting {
         args.push("--lexical-sorting".to_string());
@@ -200,8 +245,15 @@ fn boundary_test_generic(
         assert!(!outputs.is_empty());
         if allow_ambiguous && ambiguous {
             assert!(outputs.len() > 1);
+            for out in &outputs {
+                assert_eq!(version_without_build(out), expected_key);
+            }
+        } else if lexical_sorting && ambiguous {
+            assert_eq!(outputs.len(), 1);
+            assert_eq!(outputs[0], expected_lexical_pick(&filtered, kind_max, reverse));
         } else {
             assert_eq!(outputs.len(), 1);
+            assert_eq!(version_without_build(&outputs[0]), expected_key);
         }
     }
 }
@@ -215,23 +267,25 @@ proptest! {
     #[test]
     fn prop_max_small(
         stable: bool,
+        reverse: bool,
         lexical_sorting: bool,
         allow_ambiguous: bool,
         filter in arb_optional_version_req(0.5, 2),
         versions in arb_vec_versions(BOUNDARY_TEST_VERSION_COUNT_SMALL),
     ) {
-        boundary_test_generic(COMMAND_MAX, true, stable, lexical_sorting, allow_ambiguous, filter, versions);
+        boundary_test_generic(COMMAND_MAX, true, stable, reverse, lexical_sorting, allow_ambiguous, filter, versions);
     }
 
     #[test]
     fn prop_min_small(
         stable: bool,
+        reverse: bool,
         lexical_sorting: bool,
         allow_ambiguous: bool,
         filter in arb_optional_version_req(0.5, 2),
         versions in arb_vec_versions(BOUNDARY_TEST_VERSION_COUNT_SMALL),
     ) {
-        boundary_test_generic(COMMAND_MIN, false, stable, lexical_sorting, allow_ambiguous, filter, versions);
+        boundary_test_generic(COMMAND_MIN, false, stable, reverse, lexical_sorting, allow_ambiguous, filter, versions);
     }
 
     #[test]

--- a/tests/cli_min_max.rs
+++ b/tests/cli_min_max.rs
@@ -105,13 +105,7 @@ fn boundary_precedence_key(versions: &[Version], kind_max: bool) -> Version {
     versions
         .iter()
         .map(version_without_build)
-        .min_by(|a, b| {
-            if kind_max {
-                b.cmp(a)
-            } else {
-                a.cmp(b)
-            }
-        })
+        .min_by(|a, b| if kind_max { b.cmp(a) } else { a.cmp(b) })
         .expect("non-empty")
 }
 
@@ -207,6 +201,7 @@ fn boundary_cmd_args(
     args
 }
 
+#[allow(clippy::too_many_arguments)]
 fn boundary_test_generic(
     command: &'static str,
     kind_max: bool,
@@ -219,15 +214,7 @@ fn boundary_test_generic(
 ) {
     let filtered = apply_filter(&apply_stable(&versions, stable), &filter);
     if filtered.is_empty() {
-        let args = boundary_cmd_args(
-            command,
-            stable,
-            reverse,
-            false,
-            false,
-            &filter,
-            &versions,
-        );
+        let args = boundary_cmd_args(command, stable, reverse, false, false, &filter, &versions);
         common_cmd()
             .args(&args)
             .assert()
@@ -268,7 +255,10 @@ fn boundary_test_generic(
             }
         } else if lexical_sorting && ambiguous {
             assert_eq!(outputs.len(), 1);
-            assert_eq!(outputs[0], expected_lexical_pick(&filtered, kind_max, reverse));
+            assert_eq!(
+                outputs[0],
+                expected_lexical_pick(&filtered, kind_max, reverse)
+            );
         } else {
             assert_eq!(outputs.len(), 1);
             assert_eq!(version_without_build(&outputs[0]), expected_key);

--- a/tests/cli_min_max.rs
+++ b/tests/cli_min_max.rs
@@ -1,0 +1,264 @@
+//! SPDX-License-Identifier: Apache-2.0
+//! Copyright 2025 canardleteer
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//! http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+use proptest::prelude::*;
+use proptest_semver::*;
+use semver::{BuildMetadata, Version, VersionReq};
+use std::collections::HashMap;
+
+mod common;
+use common::subcommands::*;
+
+use crate::common::common_cmd;
+
+#[test]
+fn cli_max_invalid_input() {
+    let assert = common_cmd().arg(COMMAND_MAX).arg("a.b.c").assert();
+    assert.append_context(COMMAND_MAX, "bad semver").failure();
+}
+
+#[test]
+fn cli_max_basic_cases() {
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_MAX)
+        .arg("1.0.0")
+        .arg("2.0.0")
+        .arg("1.5.0")
+        .assert();
+    assert
+        .append_context(COMMAND_MAX, "simple max")
+        .stdout("2.0.0\n")
+        .success();
+
+    let assert = common_cmd()
+        .arg(COMMAND_MAX)
+        .arg("0.1.2+bm0")
+        .arg("0.1.2+bm1")
+        .assert();
+    assert
+        .append_context(COMMAND_MAX, "ambiguous boundary")
+        .failure();
+
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_MAX)
+        .arg("--allow-ambiguous")
+        .arg("0.1.2+bm0")
+        .arg("0.1.2+bm1")
+        .assert();
+    assert
+        .append_context(COMMAND_MAX, "allow ambiguous")
+        .success();
+
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_MAX)
+        .arg("--stable")
+        .arg("1.0.0-alpha")
+        .arg("1.0.0")
+        .arg("2.0.0")
+        .assert();
+    assert
+        .append_context(COMMAND_MAX, "stable max")
+        .stdout("2.0.0\n")
+        .success();
+
+    let assert = common_cmd()
+        .arg("-o")
+        .arg("text")
+        .arg(COMMAND_LATEST)
+        .arg("1.0.0")
+        .arg("2.0.0")
+        .assert();
+    assert
+        .append_context(COMMAND_LATEST, "latest alias")
+        .stdout("2.0.0\n")
+        .success();
+}
+
+fn version_without_build(v: &Version) -> Version {
+    Version {
+        major: v.major,
+        minor: v.minor,
+        patch: v.patch,
+        pre: v.pre.clone(),
+        build: BuildMetadata::EMPTY,
+    }
+}
+
+fn boundary_ambiguous(versions: &[Version], kind_max: bool) -> bool {
+    if versions.is_empty() {
+        return false;
+    }
+    let mut groups: HashMap<Version, usize> = HashMap::new();
+    for v in versions {
+        *groups.entry(version_without_build(v)).or_insert(0) += 1;
+    }
+    let key = if kind_max {
+        groups.keys().max().cloned()
+    } else {
+        groups.keys().min().cloned()
+    };
+    key.and_then(|k| groups.get(&k).copied())
+        .map(|c| c > 1)
+        .unwrap_or(false)
+}
+
+fn apply_stable(versions: &[Version], stable: bool) -> Vec<Version> {
+    if stable {
+        versions
+            .iter()
+            .filter(|v| v.pre.is_empty())
+            .cloned()
+            .collect()
+    } else {
+        versions.to_vec()
+    }
+}
+
+fn apply_filter(versions: &[Version], filter: &Option<VersionReq>) -> Vec<Version> {
+    match filter {
+        Some(f) => versions.iter().filter(|v| f.matches(v)).cloned().collect(),
+        None => versions.to_vec(),
+    }
+}
+
+const BOUNDARY_TEST_VERSION_COUNT_SMALL: usize = 16;
+
+fn boundary_test_generic(
+    command: &'static str,
+    kind_max: bool,
+    stable: bool,
+    lexical_sorting: bool,
+    allow_ambiguous: bool,
+    filter: Option<VersionReq>,
+    versions: Vec<Version>,
+) {
+    let filtered = apply_filter(&apply_stable(&versions, stable), &filter);
+    if filtered.is_empty() {
+        let mut args = vec!["-o".to_string(), "text".to_string(), command.to_string()];
+        if stable {
+            args.push("--stable".to_string());
+        }
+        if let Some(filter) = &filter {
+            args.push("--filter".to_string());
+            args.push(filter.to_string());
+        }
+        args.extend(versions.iter().map(|v| v.to_string()));
+        common_cmd()
+            .args(&args)
+            .assert()
+            .append_context(command, "empty after filters")
+            .failure();
+        return;
+    }
+
+    let ambiguous = boundary_ambiguous(&filtered, kind_max);
+
+    let mut args = vec!["-o".to_string(), "text".to_string(), command.to_string()];
+    if stable {
+        args.push("--stable".to_string());
+    }
+    if lexical_sorting {
+        args.push("--lexical-sorting".to_string());
+    }
+    if allow_ambiguous {
+        args.push("--allow-ambiguous".to_string());
+    }
+    if let Some(filter) = filter {
+        args.push("--filter".to_string());
+        args.push(filter.to_string());
+    }
+    args.extend(versions.iter().map(|v| v.to_string()));
+
+    let assert = common_cmd().args(&args).assert();
+    if ambiguous && !allow_ambiguous && !lexical_sorting {
+        assert.append_context(command, "ambiguous").failure();
+    } else {
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+        assert.append_context(command, "success").success();
+        let outputs: Vec<Version> = stdout
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| Version::parse(l).expect("parse output"))
+            .collect();
+        assert!(!outputs.is_empty());
+        if allow_ambiguous && ambiguous {
+            assert!(outputs.len() > 1);
+        } else {
+            assert_eq!(outputs.len(), 1);
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        fork: true,
+        cases: 256,
+        .. ProptestConfig::default()
+    })]
+    #[test]
+    fn prop_max_small(
+        stable: bool,
+        lexical_sorting: bool,
+        allow_ambiguous: bool,
+        filter in arb_optional_version_req(0.5, 2),
+        versions in arb_vec_versions(BOUNDARY_TEST_VERSION_COUNT_SMALL),
+    ) {
+        boundary_test_generic(COMMAND_MAX, true, stable, lexical_sorting, allow_ambiguous, filter, versions);
+    }
+
+    #[test]
+    fn prop_min_small(
+        stable: bool,
+        lexical_sorting: bool,
+        allow_ambiguous: bool,
+        filter in arb_optional_version_req(0.5, 2),
+        versions in arb_vec_versions(BOUNDARY_TEST_VERSION_COUNT_SMALL),
+    ) {
+        boundary_test_generic(COMMAND_MIN, false, stable, lexical_sorting, allow_ambiguous, filter, versions);
+    }
+
+    #[test]
+    fn prop_latest_alias(
+        versions in arb_vec_versions(8),
+    ) {
+        prop_assume!(!versions.is_empty());
+        let max = common_cmd()
+            .arg("-o")
+            .arg("text")
+            .arg(COMMAND_MAX)
+            .args(versions.iter().map(|v| v.to_string()))
+            .assert();
+        let latest = common_cmd()
+            .arg("-o")
+            .arg("text")
+            .arg(COMMAND_LATEST)
+            .args(versions.iter().map(|v| v.to_string()))
+            .assert();
+        if max.get_output().status.success() {
+            let max_stdout = String::from_utf8_lossy(&max.get_output().stdout).into_owned();
+            let latest_stdout =
+                String::from_utf8_lossy(&latest.get_output().stdout).into_owned();
+            latest.append_context(COMMAND_LATEST, "alias").success();
+            prop_assert_eq!(max_stdout, latest_stdout);
+        } else {
+            latest.append_context(COMMAND_LATEST, "alias fail").failure();
+        }
+    }
+}

--- a/tests/cli_min_max.rs
+++ b/tests/cli_min_max.rs
@@ -177,41 +177,15 @@ fn apply_filter(versions: &[Version], filter: &Option<VersionReq>) -> Vec<Versio
 
 const BOUNDARY_TEST_VERSION_COUNT_SMALL: usize = 16;
 
-fn boundary_test_generic(
+fn boundary_cmd_args(
     command: &'static str,
-    kind_max: bool,
     stable: bool,
     reverse: bool,
     lexical_sorting: bool,
     allow_ambiguous: bool,
-    filter: Option<VersionReq>,
-    versions: Vec<Version>,
-) {
-    let filtered = apply_filter(&apply_stable(&versions, stable), &filter);
-    if filtered.is_empty() {
-        let mut args = vec!["-o".to_string(), "text".to_string(), command.to_string()];
-        if stable {
-            args.push("--stable".to_string());
-        }
-        if reverse {
-            args.push("--reverse".to_string());
-        }
-        if let Some(filter) = &filter {
-            args.push("--filter".to_string());
-            args.push(filter.to_string());
-        }
-        args.extend(versions.iter().map(|v| v.to_string()));
-        common_cmd()
-            .args(&args)
-            .assert()
-            .append_context(command, "empty after filters")
-            .failure();
-        return;
-    }
-
-    let ambiguous = boundary_ambiguous(&filtered, kind_max);
-    let expected_key = boundary_precedence_key(&filtered, kind_max);
-
+    filter: &Option<VersionReq>,
+    versions: &[Version],
+) -> Vec<String> {
     let mut args = vec!["-o".to_string(), "text".to_string(), command.to_string()];
     if stable {
         args.push("--stable".to_string());
@@ -230,6 +204,50 @@ fn boundary_test_generic(
         args.push(filter.to_string());
     }
     args.extend(versions.iter().map(|v| v.to_string()));
+    args
+}
+
+fn boundary_test_generic(
+    command: &'static str,
+    kind_max: bool,
+    stable: bool,
+    reverse: bool,
+    lexical_sorting: bool,
+    allow_ambiguous: bool,
+    filter: Option<VersionReq>,
+    versions: Vec<Version>,
+) {
+    let filtered = apply_filter(&apply_stable(&versions, stable), &filter);
+    if filtered.is_empty() {
+        let args = boundary_cmd_args(
+            command,
+            stable,
+            reverse,
+            false,
+            false,
+            &filter,
+            &versions,
+        );
+        common_cmd()
+            .args(&args)
+            .assert()
+            .append_context(command, "empty after filters")
+            .failure();
+        return;
+    }
+
+    let ambiguous = boundary_ambiguous(&filtered, kind_max);
+    let expected_key = boundary_precedence_key(&filtered, kind_max);
+
+    let args = boundary_cmd_args(
+        command,
+        stable,
+        reverse,
+        lexical_sorting,
+        allow_ambiguous,
+        &filter,
+        &versions,
+    );
 
     let assert = common_cmd().args(&args).assert();
     if ambiguous && !allow_ambiguous && !lexical_sorting {
@@ -290,21 +308,35 @@ proptest! {
 
     #[test]
     fn prop_latest_alias(
-        versions in arb_vec_versions(8),
+        stable: bool,
+        reverse: bool,
+        lexical_sorting: bool,
+        allow_ambiguous: bool,
+        filter in arb_optional_version_req(0.5, 2),
+        versions in arb_vec_versions(BOUNDARY_TEST_VERSION_COUNT_SMALL),
     ) {
-        prop_assume!(!versions.is_empty());
-        let max = common_cmd()
-            .arg("-o")
-            .arg("text")
-            .arg(COMMAND_MAX)
-            .args(versions.iter().map(|v| v.to_string()))
-            .assert();
-        let latest = common_cmd()
-            .arg("-o")
-            .arg("text")
-            .arg(COMMAND_LATEST)
-            .args(versions.iter().map(|v| v.to_string()))
-            .assert();
+        let max_args = boundary_cmd_args(
+            COMMAND_MAX,
+            stable,
+            reverse,
+            lexical_sorting,
+            allow_ambiguous,
+            &filter,
+            &versions,
+        );
+        let latest_args = boundary_cmd_args(
+            COMMAND_LATEST,
+            stable,
+            reverse,
+            lexical_sorting,
+            allow_ambiguous,
+            &filter,
+            &versions,
+        );
+
+        let max = common_cmd().args(&max_args).assert();
+        let latest = common_cmd().args(&latest_args).assert();
+
         if max.get_output().status.success() {
             let max_stdout = String::from_utf8_lossy(&max.get_output().stdout).into_owned();
             let latest_stdout =

--- a/tests/cli_select.rs
+++ b/tests/cli_select.rs
@@ -210,4 +210,37 @@ proptest! {
             .assert();
         assert.append_context(COMMAND_SELECT, "property test regex").success();
     }
+
+    #[test]
+    fn prop_select_fail_if_not_found_missing_optional(
+        version in arb_version(),
+        component in prop_oneof![Just("pre-release"), Just("build-metadata")],
+    ) {
+        prop_assume!(version.pre.is_empty());
+        prop_assume!(version.build.is_empty());
+        let assert = common_cmd()
+            .arg(COMMAND_SELECT)
+            .arg(component)
+            .arg(version.to_string())
+            .arg("--fail-if-not-found")
+            .assert();
+        assert.append_context(COMMAND_SELECT, "property test -F missing").failure();
+    }
+
+    #[test]
+    fn prop_select_required_components(
+        version in arb_version(),
+        component in prop_oneof![Just("major"), Just("minor"), Just("patch")],
+    ) {
+        let assert = common_cmd()
+            .arg("-o")
+            .arg("text")
+            .arg(COMMAND_SELECT)
+            .arg(component)
+            .arg(version.to_string())
+            .assert();
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).trim().to_string();
+        assert.append_context(COMMAND_SELECT, "property test required").success();
+        prop_assert!(!stdout.is_empty());
+    }
 }

--- a/tests/cli_set.rs
+++ b/tests/cli_set.rs
@@ -17,7 +17,6 @@ use proptest_semver::*;
 
 mod common;
 use common::subcommands::*;
-use semver::{BuildMetadata, Prerelease};
 
 use crate::common::common_cmd;
 
@@ -55,7 +54,7 @@ proptest! {
         .. ProptestConfig::default()
     })]
     #[test]
-    fn prop_validate_small(v in arb_version(), major: Option<u64>, minor: Option<u64>, patch: Option<u64>, pre_release: Option<String>, build_metadata: Option<String>) {
+    fn prop_validate_small(v in arb_version(), major: Option<u64>, minor: Option<u64>, patch: Option<u64>, pre_release in prop::option::of(arb_pre_release_string()), build_metadata in prop::option::of(arb_build_metadata_string())) {
         let mut assert = common_cmd();
         assert.arg(COMMAND_SET).arg(v.to_string());
 
@@ -80,18 +79,14 @@ proptest! {
             }
         };
 
-        let (pre_release_set, pre_release_checked) = match pre_release.clone() {
+        let (pre_release_set, pre_release_checked) = match &pre_release {
             None => ("".to_string(), true),
-            Some(p) => {
-                (format!("--set-pre-release={}", p), Prerelease::new(&p).is_ok())
-            }
+            Some(p) => (format!("--set-pre-release={}", p), true),
         };
 
-        let (build_metadata_set, build_metadata_checked) = match build_metadata.clone() {
+        let (build_metadata_set, build_metadata_checked) = match &build_metadata {
             None => ("".to_string(), true),
-            Some(p) => {
-                (format!("--set-build-metadata={}", p), BuildMetadata::new(&p).is_ok())
-            }
+            Some(p) => (format!("--set-build-metadata={}", p), true),
         };
 
         if major.is_some() {

--- a/tests/cli_sort.rs
+++ b/tests/cli_sort.rs
@@ -172,10 +172,16 @@ fn sort_test_generic(
     reverse: bool,
     flatten: bool,
     fail_if_potentially_ambiguous: bool,
+    stable: bool,
     filter: Option<VersionReq>,
     versions: Vec<Version>,
 ) {
-    let mut args = vec![COMMAND_SORT.to_string()];
+    let mut args = Vec::new();
+    if stable {
+        args.push("-o".to_string());
+        args.push("text".to_string());
+    }
+    args.push(COMMAND_SORT.to_string());
     if lexical_sorting {
         args.push("--lexical-sorting".to_string());
     }
@@ -187,6 +193,12 @@ fn sort_test_generic(
     }
     if fail_if_potentially_ambiguous {
         args.push("--fail-if-potentially-ambiguous".to_string());
+    }
+    if stable {
+        args.push("--stable".to_string());
+    }
+    if stable && !flatten {
+        args.push("--flatten".to_string());
     }
 
     if let Some(filter) = filter {
@@ -208,7 +220,16 @@ fn sort_test_generic(
             .append_context(COMMAND_SORT, "prop test ambiguous")
             .failure();
     } else {
-        assert.append_context(COMMAND_SORT, "prop test").success();
+        if stable {
+            let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+            assert.append_context(COMMAND_SORT, "prop test").success();
+            for line in stdout.lines().filter(|l| !l.is_empty()) {
+                let parsed = Version::parse(line).expect("stable sort output parses");
+                assert!(parsed.pre.is_empty());
+            }
+        } else {
+            assert.append_context(COMMAND_SORT, "prop test").success();
+        }
     }
 }
 
@@ -224,8 +245,8 @@ proptest! {
     // Using some large number of filters is unlikely to provide us with half the
     // test cases,
     #[test]
-    fn sort_test_small(lexical_sorting: bool, reverse: bool, flatten: bool, fail_if_potentially_ambiguous: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_SMALL)) {
-        sort_test_generic(lexical_sorting, reverse, flatten, fail_if_potentially_ambiguous, filter, versions);
+    fn sort_test_small(lexical_sorting: bool, reverse: bool, flatten: bool, fail_if_potentially_ambiguous: bool, stable: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_SMALL)) {
+        sort_test_generic(lexical_sorting, reverse, flatten, fail_if_potentially_ambiguous, stable, filter, versions);
     }
 
     // Since the filters are incredibly complex from the framework, the odds of
@@ -237,7 +258,7 @@ proptest! {
     // change the meaning of "large for windows" instead.
     #[cfg(not(windows))]
     #[test]
-    fn sort_test_large(lexical_sorting: bool, reverse: bool, flatten: bool, fail_if_potentially_ambiguous: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_LARGE)) {
-        sort_test_generic(lexical_sorting, reverse, flatten, fail_if_potentially_ambiguous, filter, versions);
+    fn sort_test_large(lexical_sorting: bool, reverse: bool, flatten: bool, fail_if_potentially_ambiguous: bool, stable: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_LARGE)) {
+        sort_test_generic(lexical_sorting, reverse, flatten, fail_if_potentially_ambiguous, stable, filter, versions);
     }
 }

--- a/tests/cli_sort.rs
+++ b/tests/cli_sort.rs
@@ -167,6 +167,25 @@ fn input_potentially_ambiguous(versions: &[Version]) -> bool {
     counts.values().any(|&c| c > 1)
 }
 
+fn apply_stable_filter(versions: &[Version], stable: bool) -> Vec<Version> {
+    if stable {
+        versions
+            .iter()
+            .filter(|v| v.pre.is_empty())
+            .cloned()
+            .collect()
+    } else {
+        versions.to_vec()
+    }
+}
+
+fn apply_sort_filter(versions: &[Version], filter: &Option<VersionReq>) -> Vec<Version> {
+    match filter {
+        Some(f) => versions.iter().filter(|v| f.matches(v)).cloned().collect(),
+        None => versions.to_vec(),
+    }
+}
+
 fn sort_test_generic(
     lexical_sorting: bool,
     reverse: bool,
@@ -201,7 +220,7 @@ fn sort_test_generic(
         args.push("--flatten".to_string());
     }
 
-    if let Some(filter) = filter {
+    if let Some(ref filter) = filter {
         args.push("--filter".to_string());
         args.push(format!("{}", filter));
     }
@@ -214,22 +233,25 @@ fn sort_test_generic(
     );
 
     let assert = common_cmd().args(&args).assert();
-    let ambiguous = input_potentially_ambiguous(&versions);
+    let filtered = apply_sort_filter(&apply_stable_filter(&versions, stable), &filter);
+    let ambiguous = input_potentially_ambiguous(&filtered);
     if fail_if_potentially_ambiguous && ambiguous {
         assert
             .append_context(COMMAND_SORT, "prop test ambiguous")
             .failure();
-    } else {
-        if stable {
-            let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
-            assert.append_context(COMMAND_SORT, "prop test").success();
-            for line in stdout.lines().filter(|l| !l.is_empty()) {
-                let parsed = Version::parse(line).expect("stable sort output parses");
-                assert!(parsed.pre.is_empty());
-            }
-        } else {
-            assert.append_context(COMMAND_SORT, "prop test").success();
+    } else if stable && filtered.is_empty() {
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+        assert.append_context(COMMAND_SORT, "prop test stable empty").success();
+        assert!(stdout.lines().all(|l| l.is_empty()));
+    } else if stable {
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+        assert.append_context(COMMAND_SORT, "prop test").success();
+        for line in stdout.lines().filter(|l| !l.is_empty()) {
+            let parsed = Version::parse(line).expect("stable sort output parses");
+            assert!(parsed.pre.is_empty());
         }
+    } else {
+        assert.append_context(COMMAND_SORT, "prop test").success();
     }
 }
 

--- a/tests/cli_sort.rs
+++ b/tests/cli_sort.rs
@@ -14,7 +14,8 @@
 //! limitations under the License.
 use proptest::prelude::*;
 use proptest_semver::*;
-use semver::{Version, VersionReq};
+use semver::{BuildMetadata, Version, VersionReq};
+use std::collections::HashMap;
 
 mod common;
 use common::subcommands::*;
@@ -148,10 +149,29 @@ const SORT_TEST_VERSION_COUNT_SMALL: usize = 32;
 #[cfg(not(windows))]
 const SORT_TEST_VERSION_COUNT_LARGE: usize = 128;
 
+fn version_without_build(v: &Version) -> Version {
+    Version {
+        major: v.major,
+        minor: v.minor,
+        patch: v.patch,
+        pre: v.pre.clone(),
+        build: BuildMetadata::EMPTY,
+    }
+}
+
+fn input_potentially_ambiguous(versions: &[Version]) -> bool {
+    let mut counts: HashMap<Version, usize> = HashMap::new();
+    for v in versions {
+        *counts.entry(version_without_build(v)).or_insert(0) += 1;
+    }
+    counts.values().any(|&c| c > 1)
+}
+
 fn sort_test_generic(
     lexical_sorting: bool,
     reverse: bool,
     flatten: bool,
+    fail_if_potentially_ambiguous: bool,
     filter: Option<VersionReq>,
     versions: Vec<Version>,
 ) {
@@ -164,6 +184,9 @@ fn sort_test_generic(
     }
     if flatten {
         args.push("--flatten".to_string());
+    }
+    if fail_if_potentially_ambiguous {
+        args.push("--fail-if-potentially-ambiguous".to_string());
     }
 
     if let Some(filter) = filter {
@@ -179,7 +202,14 @@ fn sort_test_generic(
     );
 
     let assert = common_cmd().args(&args).assert();
-    assert.append_context(COMMAND_SORT, "prop test").success();
+    let ambiguous = input_potentially_ambiguous(&versions);
+    if fail_if_potentially_ambiguous && ambiguous {
+        assert
+            .append_context(COMMAND_SORT, "prop test ambiguous")
+            .failure();
+    } else {
+        assert.append_context(COMMAND_SORT, "prop test").success();
+    }
 }
 
 proptest! {
@@ -194,8 +224,8 @@ proptest! {
     // Using some large number of filters is unlikely to provide us with half the
     // test cases,
     #[test]
-    fn sort_test_small(lexical_sorting: bool, reverse: bool, flatten: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_SMALL)) {
-        sort_test_generic(lexical_sorting, reverse, flatten, filter, versions);
+    fn sort_test_small(lexical_sorting: bool, reverse: bool, flatten: bool, fail_if_potentially_ambiguous: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_SMALL)) {
+        sort_test_generic(lexical_sorting, reverse, flatten, fail_if_potentially_ambiguous, filter, versions);
     }
 
     // Since the filters are incredibly complex from the framework, the odds of
@@ -207,7 +237,7 @@ proptest! {
     // change the meaning of "large for windows" instead.
     #[cfg(not(windows))]
     #[test]
-    fn sort_test_large(lexical_sorting: bool, reverse: bool, flatten: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_LARGE)) {
-        sort_test_generic(lexical_sorting, reverse, flatten, filter, versions);
+    fn sort_test_large(lexical_sorting: bool, reverse: bool, flatten: bool, fail_if_potentially_ambiguous: bool, filter in arb_optional_version_req(0.5, 2), versions in arb_vec_versions(SORT_TEST_VERSION_COUNT_LARGE)) {
+        sort_test_generic(lexical_sorting, reverse, flatten, fail_if_potentially_ambiguous, filter, versions);
     }
 }

--- a/tests/cli_sort.rs
+++ b/tests/cli_sort.rs
@@ -241,7 +241,9 @@ fn sort_test_generic(
             .failure();
     } else if stable && filtered.is_empty() {
         let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
-        assert.append_context(COMMAND_SORT, "prop test stable empty").success();
+        assert
+            .append_context(COMMAND_SORT, "prop test stable empty")
+            .success();
         assert!(stdout.lines().all(|l| l.is_empty()));
     } else if stable {
         let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();

--- a/tests/cli_validate.rs
+++ b/tests/cli_validate.rs
@@ -14,6 +14,7 @@
 //! limitations under the License.
 use proptest::prelude::*;
 use proptest_semver::*;
+use semver::Version;
 
 mod common;
 use common::subcommands::*;
@@ -66,5 +67,14 @@ proptest! {
     fn prop_validate_regex(v in arb_semver()) {
         let assert = common_cmd().arg(COMMAND_VALIDATE).arg(v).assert();
         assert.append_context(COMMAND_VALIDATE, "property testing").success();
+    }
+
+    #[test]
+    fn prop_validate_rejects_invalid_strings(s in "\\PC{1,32}") {
+        prop_assume!(Version::parse(&s).is_err());
+        let assert = common_cmd().arg(COMMAND_VALIDATE).arg(&s).assert();
+        assert.append_context(COMMAND_VALIDATE, "invalid default").failure();
+        let assert = common_cmd().arg(COMMAND_VALIDATE).arg("-s").arg(&s).assert();
+        assert.append_context(COMMAND_VALIDATE, "invalid -s").failure();
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -10,8 +10,9 @@ pub(crate) mod subcommands {
     pub(crate) const COMMAND_VALIDATE: &str = "validate";
     pub(crate) const COMMAND_SET: &str = "set";
     pub(crate) const COMMAND_BUMP: &str = "bump";
+    pub(crate) const COMMAND_BUMP_RESET: &str = "bump-reset";
     pub(crate) const COMMAND_SELECT: &str = "select";
-    pub(crate) const ALL_COMMANDS: [&str; 9] = [
+    pub(crate) const ALL_COMMANDS: [&str; 10] = [
         COMMAND_COMPARE,
         COMMAND_EXPLAIN,
         COMMAND_FILTER_TEST,
@@ -19,6 +20,7 @@ pub(crate) mod subcommands {
         COMMAND_SORT,
         COMMAND_VALIDATE,
         COMMAND_BUMP,
+        COMMAND_BUMP_RESET,
         COMMAND_SET,
         COMMAND_SELECT,
     ];

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -12,7 +12,10 @@ pub(crate) mod subcommands {
     pub(crate) const COMMAND_BUMP: &str = "bump";
     pub(crate) const COMMAND_BUMP_RESET: &str = "bump-reset";
     pub(crate) const COMMAND_SELECT: &str = "select";
-    pub(crate) const ALL_COMMANDS: [&str; 10] = [
+    pub(crate) const COMMAND_MIN: &str = "min";
+    pub(crate) const COMMAND_MAX: &str = "max";
+    pub(crate) const COMMAND_LATEST: &str = "latest";
+    pub(crate) const ALL_COMMANDS: [&str; 13] = [
         COMMAND_COMPARE,
         COMMAND_EXPLAIN,
         COMMAND_FILTER_TEST,
@@ -23,6 +26,9 @@ pub(crate) mod subcommands {
         COMMAND_BUMP_RESET,
         COMMAND_SET,
         COMMAND_SELECT,
+        COMMAND_MIN,
+        COMMAND_MAX,
+        COMMAND_LATEST,
     ];
 }
 

--- a/tests/snapshots/cli_insta__bump-reset.clear.1.snap
+++ b/tests/snapshots/cli_insta__bump-reset.clear.1.snap
@@ -1,0 +1,16 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - bump-reset
+    - 1.2.3-rc.1+ci
+    - "--normal-version-only"
+---
+success: true
+exit_code: 0
+----- stdout -----
+1.3.0
+----- stderr -----

--- a/tests/snapshots/cli_insta__bump-reset.major.1.snap
+++ b/tests/snapshots/cli_insta__bump-reset.major.1.snap
@@ -1,0 +1,16 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - bump-reset
+    - 1.2.3
+    - "--major"
+---
+success: true
+exit_code: 0
+----- stdout -----
+2.0.0
+----- stderr -----

--- a/tests/snapshots/cli_insta__bump-reset.simple.1.snap
+++ b/tests/snapshots/cli_insta__bump-reset.simple.1.snap
@@ -1,0 +1,15 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - bump-reset
+    - 1.2.3
+---
+success: true
+exit_code: 0
+----- stdout -----
+1.3.0
+----- stderr -----

--- a/tests/snapshots/cli_insta__latest.alias.1.snap
+++ b/tests/snapshots/cli_insta__latest.alias.1.snap
@@ -1,0 +1,17 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - latest
+    - 1.0.0
+    - 2.0.0
+---
+success: true
+exit_code: 0
+----- stdout -----
+2.0.0
+
+----- stderr -----

--- a/tests/snapshots/cli_insta__max.simple.1.snap
+++ b/tests/snapshots/cli_insta__max.simple.1.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - max
+    - 1.0.0
+    - 2.0.0
+    - 1.5.0
+---
+success: true
+exit_code: 0
+----- stdout -----
+2.0.0
+
+----- stderr -----

--- a/tests/snapshots/cli_insta__max.stable.1.snap
+++ b/tests/snapshots/cli_insta__max.stable.1.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - max
+    - "--stable"
+    - 1.0.0-alpha
+    - 1.0.0
+    - 2.0.0
+---
+success: true
+exit_code: 0
+----- stdout -----
+2.0.0
+
+----- stderr -----

--- a/tests/snapshots/cli_insta__min.simple.1.snap
+++ b/tests/snapshots/cli_insta__min.simple.1.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - "-o"
+    - text
+    - min
+    - 1.0.0
+    - 2.0.0
+    - 1.5.0
+---
+success: true
+exit_code: 0
+----- stdout -----
+1.0.0
+
+----- stderr -----

--- a/tests/snapshots/cli_insta__sort.stable.1.snap
+++ b/tests/snapshots/cli_insta__sort.stable.1.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli_insta.rs
+info:
+  program: sem-tool
+  args:
+    - sort
+    - "--stable"
+    - "--flatten"
+    - 1.0.0-alpha
+    - 1.0.0
+    - 2.0.0
+---
+success: true
+exit_code: 0
+----- stdout -----
+---
+versions:
+- 1.0.0
+- 2.0.0
+potentially_ambiguous: false
+
+----- stderr -----


### PR DESCRIPTION
## Summary
- Harden existing CLI proptest coverage (compare exit codes, explain output, generate validation, sort ambiguity, select/set/validate paths, in-process bump/set props).
- Add `bump-reset` for reset-on-bump semantics with optional pre/build clears.
- Add `min`, `max`, and `latest` boundary commands reusing `OrderedVersionMap`, plus opt-in `--stable` prerelease filtering on `sort` and boundary commands.
- Document new commands and cross-links in README and `--help`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (integration, insta, proptest suites)
- [ ] CI hygiene + testing workflows green on this branch