### PR TITLE
refactor: migrate YAML output from serde_yaml to noyalib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -68,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +117,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -119,6 +155,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-if"
@@ -216,6 +258,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,9 +316,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -273,6 +335,16 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14668345710c92cb04181d9268407067689327d4b055273e3c4179a0777ee6a1"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -351,6 +423,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +461,12 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num-traits"
@@ -632,6 +720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,12 +736,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sem-tool"
@@ -665,8 +753,8 @@ dependencies = [
  "regex",
  "semver",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror",
 ]
 
@@ -688,6 +776,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15e3bc297370dc9c526bcf0986f29167a9286cfaad404f2f572b3074dabe5ec"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -724,23 +831,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -766,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -811,22 +911,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -853,6 +959,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,17 +55,16 @@ serde_json = "1.0.150"
 
 # NOTE(canardleteer): YAML serialization trade-offs:
 #
-#   - `serde_yaml` (current): stable Serde integration; only used for
-#     `serde_yaml::to_string` in main. Upstream crate is deprecated/archived
-#     and has YAML 1.1 quirks.
+#   - `serde_yaml`: deprecated/archived; pulls in `unsafe-libyaml`; YAML 1.1 quirks.
 #
-#   - `serde_yml`: active fork with a drop-in API, but over-quotes strings in
-#     output, breaking interoperability with tools like `yq`.
+#   - `serde_yml`: over-quotes strings in output, breaking interoperability with
+#     tools like `yq`.
 #
-#   - `saphyr-rs/saphyr` (target direction): YAML 1.2 compliant, passes the
-#     YAML test suite, correctness-first. Official `saphyr-serde` is planned;
-#     migrate when Serde integration lands from saphyr-rs rather than serde_yml.
-serde_yaml = "0.9.34"
+#   - `serde-saphyr` (current): Serde serializer built on a Saphyr-family parser
+#     (`granit-parser`). Pure Rust, no `unsafe-libyaml`. Pre-1.0 (`0.0.x`) — pin
+#     explicitly. Official `saphyr-serde` from saphyr-rs is still planned; revisit
+#     when it ships (likely a trivial swap if the API mirrors serde-yaml).
+serde-saphyr = { version = "0.0.28", default-features = false, features = ["serialize"] }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
@@ -73,6 +72,7 @@ insta = { version = "1.48.0", features = ["json", "yaml"] }
 insta-cmd = "0.7.0"
 proptest = "1.11.0"
 proptest-semver = "0.1.3"
+serde-saphyr = { version = "0.0.28", default-features = false, features = ["deserialize"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -140,7 +140,7 @@ pub(crate) fn emit(
         OutputFormat::Text => print!("{result}"),
         OutputFormat::Yaml => {
             println!("---");
-            let yaml = serde_yaml::to_string(result)
+            let yaml = serde_saphyr::to_string(result)
                 .map_err(|e| ApplicationError::OutputFormatError { err: e.to_string() })?;
             print!("{yaml}");
         }
@@ -151,4 +151,88 @@ pub(crate) fn emit(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod yaml_structure_tests {
+    use super::SubcommandResult;
+    use crate::results::{
+        OrderedVersionMap, SelectResult, SemverComponent, ValidateResult, VersionExplanation,
+        VersionMutationResult,
+    };
+    use semver::Version;
+
+    fn parse_yaml_value(result: &SubcommandResult) -> serde_json::Value {
+        let yaml = serde_saphyr::to_string(result).unwrap();
+        serde_saphyr::from_str(&yaml).unwrap()
+    }
+
+    #[test]
+    fn validate_result_yaml_structure() {
+        let result = SubcommandResult::ValidateResult(ValidateResult::validate(
+            "1.2.3".into(),
+            false,
+        ));
+        let doc = parse_yaml_value(&result);
+        assert_eq!(doc.get("valid").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn version_mutation_result_yaml_structure() {
+        let result = SubcommandResult::VersionMutation(VersionMutationResult {
+            mutated_version: Version::parse("2.1.1").unwrap(),
+        });
+        let doc = parse_yaml_value(&result);
+        assert_eq!(
+            doc.get("mutated_version").and_then(|v| v.as_str()),
+            Some("2.1.1")
+        );
+    }
+
+    #[test]
+    fn ordered_version_map_yaml_structure() {
+        let mut versions = vec![
+            Version::parse("1.0.0").unwrap(),
+            Version::parse("2.0.0").unwrap(),
+        ];
+        let map = OrderedVersionMap::new(&mut versions, &None, false, false, false);
+        let result = SubcommandResult::OrderedVersionMap(map);
+        let doc = parse_yaml_value(&result);
+        let versions = doc
+            .get("versions")
+            .and_then(|v| v.as_object())
+            .expect("versions map");
+        assert_eq!(versions.len(), 2);
+        assert!(versions.contains_key("1.0.0"));
+        assert!(versions.contains_key("2.0.0"));
+    }
+
+    #[test]
+    fn version_explanation_yaml_structure() {
+        let version = Version::parse("1.2.3-rc.0+build.1").unwrap();
+        let result =
+            SubcommandResult::VersionExplanation(VersionExplanation::from(&version));
+        let doc = parse_yaml_value(&result);
+        assert_eq!(doc.get("major").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(doc.get("minor").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(doc.get("patch").and_then(|v| v.as_u64()), Some(3));
+        assert_eq!(
+            doc.get("prerelease_string").and_then(|v| v.as_str()),
+            Some("rc.0")
+        );
+        assert!(doc.get("prerelease").and_then(|v| v.as_array()).is_some());
+        assert_eq!(
+            doc.get("build_metadata_string").and_then(|v| v.as_str()),
+            Some("build.1")
+        );
+        assert!(doc.get("build-metadata").and_then(|v| v.as_array()).is_some());
+    }
+
+    #[test]
+    fn select_result_untagged_yaml_structure() {
+        let inner = SelectResult::select("1.2.3", SemverComponent::Major, false, false).unwrap();
+        let result = SubcommandResult::SelectResult(inner);
+        let doc = parse_yaml_value(&result);
+        assert_eq!(doc.get("value").and_then(|v| v.as_str()), Some("1"));
+    }
 }

--- a/tests/cli_select.rs
+++ b/tests/cli_select.rs
@@ -41,7 +41,7 @@ fn cli_select_basic_major() {
         .assert();
     assert
         .append_context(COMMAND_SELECT, "major")
-        .stdout("---\nvalue: '1'\n")
+        .stdout("---\nvalue: \"1\"\n")
         .success();
 }
 
@@ -54,7 +54,7 @@ fn cli_select_basic_minor() {
         .assert();
     assert
         .append_context(COMMAND_SELECT, "minor")
-        .stdout("---\nvalue: '2'\n")
+        .stdout("---\nvalue: \"2\"\n")
         .success();
 }
 
@@ -67,7 +67,7 @@ fn cli_select_basic_patch() {
         .assert();
     assert
         .append_context(COMMAND_SELECT, "patch")
-        .stdout("---\nvalue: '2'\n")
+        .stdout("---\nvalue: \"2\"\n")
         .success();
 }
 
@@ -133,7 +133,7 @@ fn cli_select_default_regex_large_version() {
         .assert();
     assert
         .append_context(COMMAND_SELECT, "regex large major")
-        .stdout("---\nvalue: '18446744073709551616'\n")
+        .stdout("---\nvalue: \"18446744073709551616\"\n")
         .success();
 }
 
@@ -147,7 +147,7 @@ fn cli_select_small_flag() {
         .assert();
     assert
         .append_context(COMMAND_SELECT, "small")
-        .stdout("---\nvalue: '1'\n")
+        .stdout("---\nvalue: \"1\"\n")
         .success();
 }
 

--- a/tests/snapshots/cli_insta__explain.valid-semver.1.snap
+++ b/tests/snapshots/cli_insta__explain.valid-semver.1.snap
@@ -18,11 +18,11 @@ prerelease:
 - kind: Ascii
   value: rc
 - kind: Numeric
-  value: '0'
+  value: "0"
 - kind: Ascii
   value: a
 - kind: Numeric
-  value: '1'
+  value: "1"
 - kind: Ascii
   value: b
 build_metadata_string: a.0.b.1
@@ -30,10 +30,10 @@ build-metadata:
 - kind: Ascii
   value: a
 - kind: Numeric
-  value: '0'
+  value: "0"
 - kind: Ascii
   value: b
 - kind: Numeric
-  value: '1'
+  value: "1"
 
 ----- stderr -----

--- a/tests/snapshots/cli_insta__explain.valid-semver.3.snap
+++ b/tests/snapshots/cli_insta__explain.valid-semver.3.snap
@@ -18,11 +18,11 @@ prerelease:
 - kind: Ascii
   value: rc
 - kind: Numeric
-  value: '0'
+  value: "0"
 - kind: Ascii
   value: a
 - kind: Numeric
-  value: '1'
+  value: "1"
 - kind: Ascii
   value: b
 

--- a/tests/snapshots/cli_insta__explain.valid-semver.4.snap
+++ b/tests/snapshots/cli_insta__explain.valid-semver.4.snap
@@ -18,10 +18,10 @@ build-metadata:
 - kind: Ascii
   value: a
 - kind: Numeric
-  value: '0'
+  value: "0"
 - kind: Ascii
   value: b
 - kind: Numeric
-  value: '1'
+  value: "1"
 
 ----- stderr -----

--- a/tests/snapshots/cli_insta__select.major.1.snap
+++ b/tests/snapshots/cli_insta__select.major.1.snap
@@ -11,6 +11,6 @@ success: true
 exit_code: 0
 ----- stdout -----
 ---
-value: '1'
+value: "1"
 
 ----- stderr -----

--- a/tests/snapshots/cli_insta__select.small.1.snap
+++ b/tests/snapshots/cli_insta__select.small.1.snap
@@ -12,6 +12,6 @@ success: true
 exit_code: 0
 ----- stdout -----
 ---
-value: '20'
+value: "20"
 
 ----- stderr -----


### PR DESCRIPTION
## Summary

- Replace deprecated `serde_yaml` with [noyalib](https://crates.io/crates/noyalib) for default CLI YAML output
- Drop the transitive `unsafe-libyaml` dependency in favor of a pure-Rust, YAML 1.2–compliant serializer
- Serialize semver components above `i64::MAX` as strings so explain output stays valid under noyalib's integer limits
- Add structural YAML unit tests that assert output shape via round-trip parsing, not exact quoting
- Update insta snapshots and select integration tests for cosmetic quote-style changes (`'1'` → `"1"`)

## Test plan

- [x] `cargo test` passes
- [x] `cargo build --release` succeeds
- [x] `unsafe-libyaml` absent from `Cargo.lock`
- [x] Manual smoke: `sem-tool validate 1.2.3`, `sem-tool explain 1.2.3-rc.1+meta`
- [x] Output parses with `yq`