### PR TITLE
chore: release v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/canardleteer/sem-tool/compare/v0.1.13...v0.1.14) - 2026-07-23
+
+### Added
+
+- add default serde-yaml-compatability feature for YAML cosmetics
+
+### Fixed
+
+- rustfmt misc tests and add explain proptest regression
+
+### Other
+
+- switch to upstream noyalib
+- rename serde-yaml-compatability feature to old-yaml
+- assert explain YAML preserves u64 above i64::MAX
+- pin noyalib feat/lossless-u64 and drop u64 string workaround
+- add dual insta snapshots for compat and native YAML output
+- migrate YAML output from serde_yaml to noyalib
+- *(deps)* bump actions/cache from 5 to 6
+
 ## [0.1.13](https://github.com/canardleteer/sem-tool/compare/v0.1.12...v0.1.13) - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sem-tool"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "sem-tool"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 exclude = [
     "example-data/*",


### PR DESCRIPTION



## 🤖 New release

* `sem-tool`: 0.1.13 -> 0.1.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.14](https://github.com/canardleteer/sem-tool/compare/v0.1.13...v0.1.14) - 2026-07-23

### Added

- add default serde-yaml-compatability feature for YAML cosmetics

### Fixed

- rustfmt misc tests and add explain proptest regression

### Other

- switch to upstream noyalib
- rename serde-yaml-compatability feature to old-yaml
- assert explain YAML preserves u64 above i64::MAX
- pin noyalib feat/lossless-u64 and drop u64 string workaround
- add dual insta snapshots for compat and native YAML output
- migrate YAML output from serde_yaml to noyalib
- *(deps)* bump actions/cache from 5 to 6
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).