### PR TITLE
chore: document v0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/canardleteer/sem-tool/compare/v0.1.14...v0.2.0) - 2026-07-23
+
+### Changed
+
+- *(breaking)* remove `old-yaml` serde_yaml cosmetic compatibility; default YAML stdout now follows native noyalib quoting and layout
+
+### Other
+
+- drop dual native insta suite and update CLI/YAML expectations for noyalib output
+- refresh README Todo to match current test coverage
+
 ## [0.1.14](https://github.com/canardleteer/sem-tool/compare/v0.1.13...v0.1.14) - 2026-07-23
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds the missing `## [0.2.0]` changelog section for the already-published 0.2.0 release.
- release-plz cannot open a normal release PR here: crates.io and tag `v0.2.0` already exist, so `release-pr` reports the package as up to date.

## Context
Version bump + crates.io publish happened via #96 / release-plz `release`. The changelog-writing step (`release-pr`) was skipped because the version was already set on merge.

## Test plan
- [ ] Confirm changelog renders correctly on GitHub
- [ ] Optional: re-run cancelled cargo-dist Release for GitHub Release assets (separate from this PR)